### PR TITLE
Add user service interfaces and token management

### DIFF
--- a/EduFlow.BLL/Interfaces/Auth/ITokenService.cs
+++ b/EduFlow.BLL/Interfaces/Auth/ITokenService.cs
@@ -1,0 +1,8 @@
+﻿using EduFlow.Domain.Entities.Users;
+
+namespace EduFlow.BLL.Interfaces.Auth;
+
+public interface ITokenService
+{
+    string GenerateToken(User user);
+}

--- a/EduFlow.BLL/Interfaces/Users/Student/IStudentService.cs
+++ b/EduFlow.BLL/Interfaces/Users/Student/IStudentService.cs
@@ -1,0 +1,13 @@
+﻿using EduFlow.BLL.DTOs.Users.Student;
+
+namespace EduFlow.BLL.Interfaces.Users.Student;
+
+public interface IStudentService
+{
+    Task<IEnumerable<StudentForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<StudentForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddAsync(StudentForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(long id, StudentForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+    Task<StudentForResultDto> GetByPhoneNumberAsync(string phoneNumber, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Users/Teacher/ITeacherService.cs
+++ b/EduFlow.BLL/Interfaces/Users/Teacher/ITeacherService.cs
@@ -1,0 +1,12 @@
+﻿using EduFlow.BLL.DTOs.Users.Teacher;
+
+namespace EduFlow.BLL.Interfaces.Users.Teacher;
+
+public interface ITeacherService
+{
+    Task<IEnumerable<TeacherForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<TeacherForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddAsync(TeacherForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(TeacherForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Users/User/IUserService.cs
+++ b/EduFlow.BLL/Interfaces/Users/User/IUserService.cs
@@ -1,0 +1,15 @@
+﻿using EduFlow.BLL.DTOs.Users.User;
+
+namespace EduFlow.BLL.Interfaces.Users.User;
+
+public interface IUserService
+{
+    Task<IEnumerable<UserForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<UserForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> RegisterAsync(UserForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<string> LoginAsync(UserForLoginDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(long id, UserForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> ChangePasswordAsync(long id, UserForChangePasswordDto dto, CancellationToken cancellationToken = default);
+    Task<bool> VerifyPasswordAsync(long id, string password, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
Introduce `ITokenService` for token generation and define `IStudentService`, `ITeacherService`, and `IUserService` interfaces for managing student, teacher, and user operations. These interfaces support CRUD operations, user authentication, and password management, organized under appropriate namespaces.