### PR TITLE
Add new service interfaces and update existing ones

### DIFF
--- a/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
@@ -1,0 +1,14 @@
+﻿using EduFlow.BLL.DTOs.Courses.Attendance;
+
+namespace EduFlow.BLL.Interfaces.Courses;
+
+public interface IAttendanceService
+{
+    Task<IEnumerable<AttendanceForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<AttendanceForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddAsync(AttendanceForCraeteDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(long id, AttendanceForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AttendanceForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AttendanceForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Courses/ICategoryService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/ICategoryService.cs
@@ -1,0 +1,12 @@
+﻿using EduFlow.BLL.DTOs.Courses.Category;
+
+namespace EduFlow.BLL.Interfaces.Courses;
+
+public interface ICategoryService
+{
+    Task<IEnumerable<CategoryForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<CategoryForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddAsync(CategoryForCraeteDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(long id, CategoryForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Courses/ICourseService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/ICourseService.cs
@@ -1,0 +1,14 @@
+﻿using EduFlow.BLL.DTOs.Courses.Course;
+
+namespace EduFlow.BLL.Interfaces.Courses;
+
+public interface ICourseService
+{
+    Task<IEnumerable<CourseForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<CourseForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddAsync(CourseForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(long id, CourseForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CourseForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CourseForResultDto>> GetAllByCategoryIdAsync(long categoryId, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Messaging/IMessageService.cs
+++ b/EduFlow.BLL/Interfaces/Messaging/IMessageService.cs
@@ -1,0 +1,12 @@
+﻿using EduFlow.BLL.DTOs.Messages.Message;
+
+namespace EduFlow.BLL.Interfaces.Messaging;
+
+public interface IMessageService
+{
+    Task<IEnumerable<MessageForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<MessageForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> SendAsync(MessageForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<IEnumerable<MessageForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<MessageForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Payments/IPaymentService.cs
+++ b/EduFlow.BLL/Interfaces/Payments/IPaymentService.cs
@@ -1,0 +1,14 @@
+﻿using EduFlow.BLL.DTOs.Payments.Payment;
+
+namespace EduFlow.BLL.Interfaces.Payments;
+
+public interface IPaymentService
+{
+    Task<IEnumerable<PaymentForResultDto>> GetAllAsync(CancellationToken cancellation = default);
+    Task<PaymentForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> AddToPayAsync(PaymentForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateToPayAsync(long id, PaymentForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<PaymentForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<PaymentForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Payments/IRegistryService.cs
+++ b/EduFlow.BLL/Interfaces/Payments/IRegistryService.cs
@@ -1,0 +1,11 @@
+﻿using EduFlow.BLL.DTOs.Payments.Registry;
+
+namespace EduFlow.BLL.Interfaces.Payments;
+
+public interface IRegistryService
+{
+    Task<IEnumerable<RegistryForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<RegistryForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> IncomeAsync(RegistryForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> OutlayAsync(RegistryForCreateDto dto, CancellationToken cancellationToken = default);
+}

--- a/EduFlow.BLL/Interfaces/Users/IStudentService.cs
+++ b/EduFlow.BLL/Interfaces/Users/IStudentService.cs
@@ -1,6 +1,6 @@
 ﻿using EduFlow.BLL.DTOs.Users.Student;
 
-namespace EduFlow.BLL.Interfaces.Users.Student;
+namespace EduFlow.BLL.Interfaces.Users;
 
 public interface IStudentService
 {

--- a/EduFlow.BLL/Interfaces/Users/ITeacherService.cs
+++ b/EduFlow.BLL/Interfaces/Users/ITeacherService.cs
@@ -1,6 +1,6 @@
 ﻿using EduFlow.BLL.DTOs.Users.Teacher;
 
-namespace EduFlow.BLL.Interfaces.Users.Teacher;
+namespace EduFlow.BLL.Interfaces.Users;
 
 public interface ITeacherService
 {

--- a/EduFlow.BLL/Interfaces/Users/IUserService.cs
+++ b/EduFlow.BLL/Interfaces/Users/IUserService.cs
@@ -1,6 +1,6 @@
 ﻿using EduFlow.BLL.DTOs.Users.User;
 
-namespace EduFlow.BLL.Interfaces.Users.User;
+namespace EduFlow.BLL.Interfaces.Users;
 
 public interface IUserService
 {


### PR DESCRIPTION
This commit introduces several new service interfaces for courses, attendance, categories, messages, payments, and registries, each with methods for common operations like retrieving, adding, updating, and deleting records. The existing student, teacher, and user service interfaces have been updated to use a more general namespace, consolidating them under `EduFlow.BLL.Interfaces.Users`. The core functionality of these interfaces remains unchanged, enhancing the organization of the codebase.