### PR TITLE
Add new service classes for various functionalities

### DIFF
--- a/EduFlow.BLL/Services/Auth/TokenService.cs
+++ b/EduFlow.BLL/Services/Auth/TokenService.cs
@@ -1,0 +1,12 @@
+﻿using EduFlow.BLL.Interfaces.Auth;
+using EduFlow.Domain.Entities.Users;
+
+namespace EduFlow.BLL.Services.Auth;
+
+public class TokenService : ITokenService
+{
+    public string GenerateToken(User user)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Courses/AttendanceService.cs
+++ b/EduFlow.BLL/Services/Courses/AttendanceService.cs
@@ -1,0 +1,42 @@
+﻿using EduFlow.BLL.DTOs.Courses.Attendance;
+using EduFlow.BLL.Interfaces.Courses;
+
+namespace EduFlow.BLL.Services.Courses;
+
+public class AttendanceService : IAttendanceService
+{
+    public Task<bool> AddAsync(AttendanceForCraeteDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<AttendanceForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<AttendanceForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<AttendanceForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<AttendanceForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(long id, AttendanceForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Courses/CategoryService.cs
+++ b/EduFlow.BLL/Services/Courses/CategoryService.cs
@@ -1,0 +1,32 @@
+﻿using EduFlow.BLL.DTOs.Courses.Category;
+using EduFlow.BLL.Interfaces.Courses;
+
+namespace EduFlow.BLL.Services.Courses;
+
+public class CategoryService : ICategoryService
+{
+    public Task<bool> AddAsync(CategoryForCraeteDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<CategoryForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<CategoryForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(long id, CategoryForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Courses/CourseService.cs
+++ b/EduFlow.BLL/Services/Courses/CourseService.cs
@@ -1,0 +1,42 @@
+﻿using EduFlow.BLL.DTOs.Courses.Course;
+using EduFlow.BLL.Interfaces.Courses;
+
+namespace EduFlow.BLL.Services.Courses;
+
+public class CourseService : ICourseService
+{
+    public Task<bool> AddAsync(CourseForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<CourseForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<CourseForResultDto>> GetAllByCategoryIdAsync(long categoryId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<CourseForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<CourseForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(long id, CourseForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Messaging/MessageService.cs
+++ b/EduFlow.BLL/Services/Messaging/MessageService.cs
@@ -1,0 +1,32 @@
+﻿using EduFlow.BLL.DTOs.Messages.Message;
+using EduFlow.BLL.Interfaces.Messaging;
+
+namespace EduFlow.BLL.Services.Messaging;
+
+public class MessageService : IMessageService
+{
+    public Task<IEnumerable<MessageForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<MessageForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<MessageForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<MessageForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> SendAsync(MessageForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Payments/PaymentService.cs
+++ b/EduFlow.BLL/Services/Payments/PaymentService.cs
@@ -1,0 +1,42 @@
+﻿using EduFlow.BLL.DTOs.Payments.Payment;
+using EduFlow.BLL.Interfaces.Payments;
+
+namespace EduFlow.BLL.Services.Payments;
+
+public class PaymentService : IPaymentService
+{
+    public Task<bool> AddToPayAsync(PaymentForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<PaymentForResultDto>> GetAllAsync(CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<PaymentForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<PaymentForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<PaymentForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateToPayAsync(long id, PaymentForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Payments/RegistryService.cs
+++ b/EduFlow.BLL/Services/Payments/RegistryService.cs
@@ -1,0 +1,27 @@
+﻿using EduFlow.BLL.DTOs.Payments.Registry;
+using EduFlow.BLL.Interfaces.Payments;
+
+namespace EduFlow.BLL.Services.Payments;
+
+public class RegistryService : IRegistryService
+{
+    public Task<IEnumerable<RegistryForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<RegistryForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> IncomeAsync(RegistryForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> OutlayAsync(RegistryForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Users/StudentService.cs
+++ b/EduFlow.BLL/Services/Users/StudentService.cs
@@ -1,0 +1,37 @@
+﻿using EduFlow.BLL.DTOs.Users.Student;
+using EduFlow.BLL.Interfaces.Users;
+
+namespace EduFlow.BLL.Services.Users;
+
+public class StudentService : IStudentService
+{
+    public Task<bool> AddAsync(StudentForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<StudentForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<StudentForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<StudentForResultDto> GetByPhoneNumberAsync(string phoneNumber, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(long id, StudentForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Users/TeacherService.cs
+++ b/EduFlow.BLL/Services/Users/TeacherService.cs
@@ -1,0 +1,32 @@
+﻿using EduFlow.BLL.DTOs.Users.Teacher;
+using EduFlow.BLL.Interfaces.Users;
+
+namespace EduFlow.BLL.Services.Users;
+
+public class TeacherService : ITeacherService
+{
+    public Task<bool> AddAsync(TeacherForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<TeacherForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<TeacherForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(TeacherForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.BLL/Services/Users/UserService.cs
+++ b/EduFlow.BLL/Services/Users/UserService.cs
@@ -1,0 +1,47 @@
+﻿using EduFlow.BLL.DTOs.Users.User;
+using EduFlow.BLL.Interfaces.Users;
+
+namespace EduFlow.BLL.Services.Users;
+
+public class UserService : IUserService
+{
+    public Task<bool> ChangePasswordAsync(long id, UserForChangePasswordDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<UserForResultDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<UserForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<string> LoginAsync(UserForLoginDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> RegisterAsync(UserForCreateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(long id, UserForUpdateDto dto, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> VerifyPasswordAsync(long id, string password, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
This commit introduces several new service classes in the EduFlow.BLL.Services namespace, including `TokenService`, `AttendanceService`, `CategoryService`, `CourseService`, `MessageService`, `PaymentService`, `RegistryService`, `StudentService`, `TeacherService`, and `UserService`. Each service implements its respective interface and contains methods that currently throw a `NotImplementedException`. These services are intended to manage functionalities related to authentication, attendance, categories, courses, messaging, payments, registries, students, teachers, and users. Additionally, necessary using directives for DTOs and interfaces have been added.