### PR TITLE
Add Newtonsoft.Json support for JSON serialization

### DIFF
--- a/EduFlow.WebApi/EduFlow.WebApi.csproj
+++ b/EduFlow.WebApi/EduFlow.WebApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -17,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />

--- a/EduFlow.WebApi/Program.cs
+++ b/EduFlow.WebApi/Program.cs
@@ -7,7 +7,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 LayerConfiguration.AddSerilogConfiguration(builder.Host);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddNewtonsoftJson(options =>
+    {
+        options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+    });
 
 builder.Services
     .AddEndpointsApiExplorer()


### PR DESCRIPTION
Updated `EduFlow.WebApi.csproj` to include
`Microsoft.AspNetCore.Mvc.NewtonsoftJson` and
`Newtonsoft.Json` packages. Modified `Program.cs` to configure JSON serialization to ignore reference loops, enhancing handling of complex object graphs.