### PR TITLE
Restructure MainWindow layout with navigation frame

### DIFF
--- a/EduFlow.Desktop/Windows/MainWindow.xaml
+++ b/EduFlow.Desktop/Windows/MainWindow.xaml
@@ -70,7 +70,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Grid>
+            <Grid Grid.Row="0">
                 <StackPanel Orientation="Horizontal"
                             Margin="10 0"
                             Width="85"
@@ -93,6 +93,11 @@
                                  ToolTip="Maximize"
                                  Click="MaxButton_Click"/>
                 </StackPanel>
+            </Grid>
+
+            <Grid Grid.Row="1" Margin="0 5 10 5">
+                <Frame Name="Navigate"
+                       NavigationUIVisibility="Hidden"/>
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
Updated the `Grid` in `MainWindow.xaml` to include two rows. The first row contains a `StackPanel` with a `RadioButton`, and the second row features a `Frame` for navigation, which has its `NavigationUIVisibility` set to hidden for a cleaner interface.