### PR TITLE
Refactor MainPage layout and update course count

### DIFF
--- a/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml
+++ b/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml
@@ -116,8 +116,11 @@
 
         <Grid Grid.Row="1"
               Margin="0 10">
-            <StackPanel>
-                <Grid Height="25"
+            <Grid.RowDefinitions>
+                <RowDefinition Height="25"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid Grid.Row="0"
                       Margin="3 0 18 0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="50"/>
@@ -158,11 +161,12 @@
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center"/>
                 </Grid>
-                
+
+            <Grid Grid.Row="1">
                 <ScrollViewer>
                     <StackPanel x:Name="stCourses"/>
                 </ScrollViewer>
-            </StackPanel>
+            </Grid>
         </Grid>
     </Grid>
 </Page>

--- a/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml.cs
@@ -19,7 +19,7 @@ public partial class MainPage : Page
         int count = 0;
         stCourses.Children.Clear();
 
-        for(int i = count; i < 10; i++)
+        for(int i = count; i < 20; i++)
         {
             MainForCourseComponent component = new MainForCourseComponent();
             component.SetValues(count, long.Parse(count.ToString()), "Foundation", 10, "Abdulvosid");


### PR DESCRIPTION
Updated the XAML layout for `MainPage` to use a new `Grid` structure, replacing the previous `StackPanel` with a `ScrollViewer` containing a `StackPanel` named `stCourses`. This improves UI element arrangement.

In `MainPage.xaml.cs`, modified the `GetAllCourse` method to increase the loop iteration from `10` to `20`, doubling the number of course components displayed.