### PR TITLE
Reset course and student counts; load teachers

### DIFF
--- a/EduFlow.Desktop.Integrated/Security/TokenHandler.cs
+++ b/EduFlow.Desktop.Integrated/Security/TokenHandler.cs
@@ -20,9 +20,9 @@ public static class TokenHandler
             switch(claim.Type)
             {
                 case "Id": identity.Id = long.Parse(claim.Value); break;
-                case "Name": identity.Name = claim.Value; break;
+                case "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": identity.Name = claim.Value; break;
                 case "PhoneNumber": identity.PhoneNumber = claim.Value; break;
-                case "Role": identity.Role = Enum.Parse<UserRole>(claim.Value); break;
+                case "http://schemas.microsoft.com/ws/2008/06/identity/claims/role": identity.Role = Enum.Parse<UserRole>(claim.Value); break;
             }
         }
 

--- a/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml
+++ b/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml
@@ -71,7 +71,7 @@
                         Background="Tomato">
                     <StackPanel VerticalAlignment="Center">
                         <TextBlock x:Name="YourCoursesCount"
-                                   Text="3"
+                                   Text="0"
                                    Foreground="White"
                                    FontSize="22"
                                    HorizontalAlignment="Center"
@@ -93,7 +93,7 @@
                         Background="DeepSkyBlue">
                     <StackPanel VerticalAlignment="Center">
                         <TextBlock x:Name="YourStudentsCount"
-                                   Text="3"
+                                   Text="0"
                                    Foreground="White"
                                    FontSize="22"
                                    HorizontalAlignment="Center"

--- a/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/MainForPage/MainPage.xaml.cs
@@ -56,6 +56,26 @@ public partial class MainPage : Page
         ShowCourse(courses);
     }
 
+    private async Task GetAllTeachers()
+    {
+        var teachers = await Task.Run(async () => await _teacherService.GetAllAsync());
+
+        if (teachers.Any())
+        {
+            foreach(var teacher in teachers)
+            {
+                ComboBoxItem item = new ComboBoxItem();
+                item.Content = teacher.User.Firstname;
+                item.Tag = teacher.Id;
+                teacherComboBox.Items.Add(item);
+            }
+        }
+        else
+        {
+            notifier.ShowInformation("Ustozlar topilmadi!");
+        }
+    }
+
     private async Task GetAllCourse()
     {
         stCourses.Children.Clear();
@@ -86,6 +106,9 @@ public partial class MainPage : Page
                 stCourses.Children.Add(component);
                 count++;
             }
+
+            YourCoursesCount.Text = count.ToString();
+            YourStudentsCount.Text = courses.Sum(x => x.Students.Count).ToString();
         }
         else
         {
@@ -126,6 +149,7 @@ public partial class MainPage : Page
         else
         {
             await GetAllCourse();
+            await GetAllTeachers();
             notifier.ShowInformation($"{fullName} xush kelibsiz!");
         }
     }

--- a/EduFlow.Desktop/Pages/MainForPage/ManagerNavigationPage.xaml
+++ b/EduFlow.Desktop/Pages/MainForPage/ManagerNavigationPage.xaml
@@ -5,13 +5,16 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:EduFlow.Desktop.Pages.MainForPage"
       mc:Ignorable="d" 
-      Title="ManagerNavigationPage">
+      Title="ManagerNavigationPage"
+      Loaded="Page_Loaded">
 
     <StackPanel>
         <RadioButton x:Name="MainButton"
-                    Style="{DynamicResource MainButton}"/>
+                     Style="{DynamicResource MainButton}"
+                     Click="MainButton_Click"/>
 
         <RadioButton x:Name="CoursesButton"
-                    Style="{DynamicResource CourseButton}"/>
+                     Style="{DynamicResource CourseButton}"
+                     Click="CoursesButton_Click"/>
     </StackPanel>
 </Page>

--- a/EduFlow.Desktop/Pages/MainForPage/ManagerNavigationPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/MainForPage/ManagerNavigationPage.xaml.cs
@@ -1,28 +1,47 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using EduFlow.Desktop.Pages.CourseForPages;
+using EduFlow.Desktop.Windows;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace EduFlow.Desktop.Pages.MainForPage
+namespace EduFlow.Desktop.Pages.MainForPage;
+
+/// <summary>
+/// Interaction logic for ManagerNavigationPage.xaml
+/// </summary>
+public partial class ManagerNavigationPage : Page
 {
-    /// <summary>
-    /// Interaction logic for ManagerNavigationPage.xaml
-    /// </summary>
-    public partial class ManagerNavigationPage : Page
+    public ManagerNavigationPage()
     {
-        public ManagerNavigationPage()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+    }
+
+    private MainWindow GetMainWindow()
+        => Window.GetWindow(this) as MainWindow;
+
+    private void GetMainPage()
+    {
+        MainButton.IsChecked = true;
+        MainPage page = new MainPage();
+        var window = GetMainWindow();
+        if(window != null)
+            window.NavigatePage(page);
+    }
+    private void MainButton_Click(object sender, RoutedEventArgs e)
+    {
+        GetMainPage();
+    }
+
+    private void CoursesButton_Click(object sender, RoutedEventArgs e)
+    {
+        CoursesButton.IsChecked = true;
+        CoursePage page = new CoursePage();
+        var window = GetMainWindow(); 
+        if(window != null)
+            window.NavigatePage(page);
+    }
+
+    private void Page_Loaded(object sender, RoutedEventArgs e)
+    {
+        GetMainPage();
     }
 }

--- a/EduFlow.Desktop/Pages/MainForPage/TeacherNavigationPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/MainForPage/TeacherNavigationPage.xaml.cs
@@ -24,6 +24,7 @@ public partial class TeacherNavigationPage : Page
 
     private void GetMainPage()
     {
+        MainButton.IsChecked = true;
         MainPage page = new MainPage();
         var window = getWindow();
         if (window != null)
@@ -37,6 +38,7 @@ public partial class TeacherNavigationPage : Page
 
     private void CoursesButton_Click(object sender, RoutedEventArgs e)
     {
+        CoursesButton.IsChecked = true;
         CoursePage page = new CoursePage();
         var window = getWindow();
         if(window != null)


### PR DESCRIPTION
Updated `YourCoursesCount` and `YourStudentsCount` to initialize to "0". Added `GetAllTeachers` method to fetch and display teachers in a `ComboBox`. Modified `GetAllCourse` to update counts based on retrieved data. Adjusted `Page_Loaded` to ensure both courses and teachers are loaded on page access.