### PR TITLE
Add StudentCourse management to AppDbContext

### DIFF
--- a/EduFLow.DAL/Data/AppDbContext.cs
+++ b/EduFLow.DAL/Data/AppDbContext.cs
@@ -18,4 +18,5 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<Registry> Registry { get; set; }
     public DbSet<Payment> Payments { get; set; }
     public DbSet<Message> Messages { get; set; }
+    public DbSet<StudentCourse> StudentCourses { get; set; }
 }

--- a/EduFLow.DAL/Interfaces/Courses/IStudentCourseRepository.cs
+++ b/EduFLow.DAL/Interfaces/Courses/IStudentCourseRepository.cs
@@ -1,0 +1,7 @@
+﻿using EduFlow.Domain.Entities.Courses;
+
+namespace EduFlow.DAL.Interfaces.Courses;
+
+public interface IStudentCourseRepository : IRepository<StudentCourse>
+{
+}

--- a/EduFLow.DAL/Interfaces/IUnitOfWork.cs
+++ b/EduFLow.DAL/Interfaces/IUnitOfWork.cs
@@ -17,5 +17,6 @@ public interface IUnitOfWork
     public IRegistryRepository Registry { get; set; }
     public IPaymentRepository Payment { get; set; }
     public IMessageRepository Message { get; set; }
+    public IStudentCourseRepository StudentCourse { get; set; }
     public Task<int> SaveAsync(CancellationToken cancellation = default);
 }

--- a/EduFLow.DAL/Migrations/20250420174752_FirstMigration.Designer.cs
+++ b/EduFLow.DAL/Migrations/20250420174752_FirstMigration.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EduFlow.DAL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20250419190700_FirstMigration")]
+    [Migration("20250420174752_FirstMigration")]
     partial class FirstMigration
     {
         /// <inheritdoc />
@@ -239,7 +239,7 @@ namespace EduFlow.DAL.Migrations
 
                     b.HasIndex("StudentId");
 
-                    b.ToTable("StudentCourse");
+                    b.ToTable("StudentCourses");
                 });
 
             modelBuilder.Entity("EduFlow.Domain.Entities.Messaging.Message", b =>

--- a/EduFLow.DAL/Migrations/20250420174752_FirstMigration.cs
+++ b/EduFLow.DAL/Migrations/20250420174752_FirstMigration.cs
@@ -115,7 +115,7 @@ namespace EduFlow.DAL.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "StudentCourse",
+                name: "StudentCourses",
                 columns: table => new
                 {
                     id = table.Column<long>(type: "bigint", nullable: false)
@@ -129,15 +129,15 @@ namespace EduFlow.DAL.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_StudentCourse", x => x.id);
+                    table.PrimaryKey("PK_StudentCourses", x => x.id);
                     table.ForeignKey(
-                        name: "FK_StudentCourse_Courses_course_id",
+                        name: "FK_StudentCourses_Courses_course_id",
                         column: x => x.course_id,
                         principalTable: "Courses",
                         principalColumn: "id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
-                        name: "FK_StudentCourse_Students_student_id",
+                        name: "FK_StudentCourses_Students_student_id",
                         column: x => x.student_id,
                         principalTable: "Students",
                         principalColumn: "id",
@@ -385,13 +385,13 @@ namespace EduFlow.DAL.Migrations
                 column: "student_id");
 
             migrationBuilder.CreateIndex(
-                name: "IX_StudentCourse_course_id",
-                table: "StudentCourse",
+                name: "IX_StudentCourses_course_id",
+                table: "StudentCourses",
                 column: "course_id");
 
             migrationBuilder.CreateIndex(
-                name: "IX_StudentCourse_student_id",
-                table: "StudentCourse",
+                name: "IX_StudentCourses_student_id",
+                table: "StudentCourses",
                 column: "student_id");
 
             migrationBuilder.CreateIndex(
@@ -421,7 +421,7 @@ namespace EduFlow.DAL.Migrations
                 name: "Payments");
 
             migrationBuilder.DropTable(
-                name: "StudentCourse");
+                name: "StudentCourses");
 
             migrationBuilder.DropTable(
                 name: "Groups");

--- a/EduFLow.DAL/Migrations/AppDbContextModelSnapshot.cs
+++ b/EduFLow.DAL/Migrations/AppDbContextModelSnapshot.cs
@@ -236,7 +236,7 @@ namespace EduFlow.DAL.Migrations
 
                     b.HasIndex("StudentId");
 
-                    b.ToTable("StudentCourse");
+                    b.ToTable("StudentCourses");
                 });
 
             modelBuilder.Entity("EduFlow.Domain.Entities.Messaging.Message", b =>

--- a/EduFLow.DAL/Repositories/Courses/StudentCourseRepository.cs
+++ b/EduFLow.DAL/Repositories/Courses/StudentCourseRepository.cs
@@ -1,0 +1,17 @@
+﻿using EduFlow.DAL.Data;
+using EduFlow.DAL.Interfaces.Courses;
+using EduFlow.Domain.Entities.Courses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EduFlow.DAL.Repositories.Courses;
+
+public class StudentCourseRepository : Repository<StudentCourse>, IStudentCourseRepository
+{
+    private readonly AppDbContext _context;
+    private DbSet<StudentCourse> _dbSet;
+    public StudentCourseRepository(AppDbContext context) : base(context)
+    {
+        this._context = context;
+        this._dbSet = _context.Set<StudentCourse>();
+    }
+}

--- a/EduFLow.DAL/Repositories/UnitOfWork.cs
+++ b/EduFLow.DAL/Repositories/UnitOfWork.cs
@@ -23,6 +23,7 @@ public class UnitOfWork(AppDbContext context) : IUnitOfWork, IDisposable
     public IPaymentRepository Payment { get; set; } = new PaymentRepository(context);
     public IMessageRepository Message { get; set; } = new MessageRepository(context);
     public IGroupRepository Group { get; set; } = new GroupRepository(context);
+    public IStudentCourseRepository StudentCourse { get; set; } = new StudentCourseRepository(context);
 
     public void Dispose()
         => GC.SuppressFinalize(this);

--- a/EduFlow.BLL/Common/Mapping/MappingProfile.cs
+++ b/EduFlow.BLL/Common/Mapping/MappingProfile.cs
@@ -3,6 +3,7 @@ using EduFlow.BLL.DTOs.Courses.Attendance;
 using EduFlow.BLL.DTOs.Courses.Category;
 using EduFlow.BLL.DTOs.Courses.Course;
 using EduFlow.BLL.DTOs.Courses.Group;
+using EduFlow.BLL.DTOs.Courses.StudentCourse;
 using EduFlow.BLL.DTOs.Messages.Message;
 using EduFlow.BLL.DTOs.Payments.Payment;
 using EduFlow.BLL.DTOs.Payments.Registry;
@@ -56,6 +57,12 @@ public class MappingProfile : Profile
         CreateMap<GroupForUpdateDto, Group>()
             .ForMember(dest => dest.Students, opt => opt.Ignore())
             .ForMember(dest => dest.Payments, opt => opt.Ignore());
+
+        /*-------------------------------------StudentCourse----------------------------------*/
+        CreateMap<StudentCourse, StudentCourseForResultDto>();
+        CreateMap<StudentCourseForResultDto, StudentCourse>();
+        CreateMap<StudentCourseForCreateDto, StudentCourse>();
+        CreateMap<StudentCourseForUpdateDto, StudentCourse>();
 
         /*-------------------------------------Category-----------------------------------------*/
         CreateMap<Category, CategoryForResultDto>();

--- a/EduFlow.BLL/Common/Validators/Courses/Interfaces/IStudentCourseValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Interfaces/IStudentCourseValidator.cs
@@ -1,0 +1,10 @@
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using FluentValidation.Results;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Interfaces;
+
+public interface IStudentCourseValidator
+{
+    Task<ValidationResult> ValidateCreate(StudentCourseForCreateDto dto);
+    Task<ValidationResult> ValidateUpdate(StudentCourseForUpdateDto dto);
+}

--- a/EduFlow.BLL/Common/Validators/Courses/Services/StudentCourseValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Services/StudentCourseValidator.cs
@@ -1,0 +1,19 @@
+﻿using EduFlow.BLL.Common.Validators.Courses.Interfaces;
+using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Services;
+
+public class StudentCourseValidator(
+    IValidator<StudentCourseForCreateDto> createValidator,
+    IValidator<StudentCourseForUpdateDto> updateValidator) : IStudentCourseValidator
+{
+    private readonly IValidator<StudentCourseForCreateDto> _createValidator = createValidator;
+    private readonly IValidator<StudentCourseForUpdateDto> _updateValidator = updateValidator;
+    public async Task<ValidationResult> ValidateCreate(StudentCourseForCreateDto dto)
+        => await _createValidator.ValidateAsync(dto);
+
+    public async Task<ValidationResult> ValidateUpdate(StudentCourseForUpdateDto dto)
+        => await _updateValidator.ValidateAsync(dto);
+}

--- a/EduFlow.BLL/Common/Validators/Courses/StudentCourse/StudentCourseForCreateValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/StudentCourse/StudentCourseForCreateValidator.cs
@@ -1,0 +1,18 @@
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using FluentValidation;
+
+namespace EduFlow.BLL.Common.Validators.Courses.StudentCourse;
+
+public class StudentCourseForCreateValidator : AbstractValidator<StudentCourseForCreateDto>
+{
+    public StudentCourseForCreateValidator()
+    {
+        RuleFor(x => x.StudentId)
+            .NotEmpty().WithMessage("Talaba Id si kiritish majburiy")
+            .GreaterThan(0).WithMessage("Talaba Id si 0 dan katta bo'lishi kerak");
+
+        RuleFor(x => x.CourseId)
+            .NotEmpty().WithMessage("Kurs Id si kiritish majburiy")
+            .GreaterThan(0).WithMessage("Kurs Id si 0 dan katta bo'lishi kerak");
+    }
+}

--- a/EduFlow.BLL/Common/Validators/Courses/StudentCourse/StudentCourseForUpdateValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/StudentCourse/StudentCourseForUpdateValidator.cs
@@ -1,0 +1,18 @@
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using FluentValidation;
+
+namespace EduFlow.BLL.Common.Validators.Courses.StudentCourse;
+
+public class StudentCourseForUpdateValidator : AbstractValidator<StudentCourseForUpdateDto>
+{
+    public StudentCourseForUpdateValidator()
+    {
+        RuleFor(x => x.StudentId)
+            .NotEmpty().WithMessage("Talaba Id si kiritish majburiy")
+            .GreaterThan(0).WithMessage("Talaba Id si 0 dan katta bo'lishi kerak");
+
+        RuleFor(x => x.CourseId)
+            .NotEmpty().WithMessage("Kurs Id si kiritish majburiy")
+            .GreaterThan(0).WithMessage("Kurs Id si 0 dan katta bo'lishi kerak");
+    }
+}

--- a/EduFlow.BLL/DTOs/Courses/Course/CourseForResultDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Course/CourseForResultDto.cs
@@ -17,4 +17,5 @@ public class CourseForResultDto
     public Et.Category Category { get; set; }
     public List<Teacher> Teachers { get; set; }
     public List<Et.Group> Groups { get; set; }
+    public List<Et.StudentCourse> Students { get; set; }
 }

--- a/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForCreateDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForCreateDto.cs
@@ -1,0 +1,7 @@
+﻿namespace EduFlow.BLL.DTOs.Courses.StudentCourse;
+
+public class StudentCourseForCreateDto
+{
+    public long StudentId { get; set; }
+    public long CourseId { get; set; }
+}

--- a/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForResultDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForResultDto.cs
@@ -1,0 +1,15 @@
+﻿using Et = EduFlow.Domain.Entities.Courses;
+using EduFlow.Domain.Entities.Users;
+
+namespace EduFlow.BLL.DTOs.Courses.StudentCourse;
+
+public class StudentCourseForResultDto
+{
+    public long Id { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public long StudentId { get; set; }
+    public Student Student { get; set; }
+    public long CourseId { get; set; }
+    public Et.Course Course { get; set; }
+}

--- a/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForUpdateDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/StudentCourse/StudentCourseForUpdateDto.cs
@@ -1,0 +1,7 @@
+﻿namespace EduFlow.BLL.DTOs.Courses.StudentCourse;
+
+public class StudentCourseForUpdateDto
+{
+    public long StudentId { get; set; }
+    public long CourseId { get; set; }
+}

--- a/EduFlow.BLL/DTOs/Users/Student/StudentForResultDto.cs
+++ b/EduFlow.BLL/DTOs/Users/Student/StudentForResultDto.cs
@@ -12,6 +12,7 @@ public class StudentForResultDto
     public int Age { get; set; }
     public string? Address { get; set; }
     public string PhoneNumber { get; set; }
+    public List<StudentCourse> StudentCourses { get; set; }
     public List<Payment> Payments { get; set; }
     public List<Group> Groups { get; set; }
 }

--- a/EduFlow.BLL/Interfaces/Courses/IStudentCourseService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/IStudentCourseService.cs
@@ -1,0 +1,13 @@
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+
+namespace EduFlow.BLL.Interfaces.Courses;
+
+public interface IStudentCourseService
+{
+    Task<IEnumerable<StudentCourseForResultDto>> GetAllAsync(CancellationToken cancellation = default);
+    Task<StudentCourseForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default);
+    Task<bool> AddAsync(StudentCourseForCreateDto studentCourse, CancellationToken cancellation = default);
+    Task<bool> UpdateAsync(long id, StudentCourseForUpdateDto studentCourse, CancellationToken cancellation = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellation = default);
+    Task<bool> ExistsAsync(long id, CancellationToken cancellation = default);
+}

--- a/EduFlow.BLL/Services/Courses/StudentCourseService.cs
+++ b/EduFlow.BLL/Services/Courses/StudentCourseService.cs
@@ -1,0 +1,160 @@
+﻿using AutoMapper;
+using EduFlow.BLL.Common.Exceptions;
+using EduFlow.BLL.Common.Validators.Courses.Interfaces;
+using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using EduFlow.BLL.Interfaces.Courses;
+using EduFlow.DAL.Interfaces;
+using EduFlow.Domain.Entities.Courses;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Net;
+
+namespace EduFlow.BLL.Services.Courses;
+
+public class StudentCourseService(
+    IUnitOfWork unitOfWork,
+    ILogger<StudentCourseService> logger,
+    IStudentCourseValidator validator,
+    IMapper mapper) : IStudentCourseService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly ILogger<StudentCourseService> _logger = logger;
+    private readonly IStudentCourseValidator _validator = validator;
+    private readonly IMapper _mapper = mapper;
+    public async Task<bool> AddAsync(StudentCourseForCreateDto studentCourse, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var validationResult = await _validator.ValidateCreate(studentCourse);
+            if(!validationResult.IsValid)
+                throw new ValidationException(validationResult.Errors);
+
+            var existsStudent = await _unitOfWork.Student.GetAsync(studentCourse.StudentId);
+            if(existsStudent is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student not found with id: {studentCourse.StudentId}");
+
+            var existsCourse = await _unitOfWork.Course.GetAsync(studentCourse.CourseId);
+            if (existsCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Course not found with id: {studentCourse.CourseId}");
+
+            var savedStudentCourse = _mapper.Map<StudentCourse>(studentCourse);
+
+            return await _unitOfWork.StudentCourse.AddConfirmAsync(savedStudentCourse);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while adding a student course: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(long id, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var existsStudentCourse = await _unitOfWork.StudentCourse.GetAsync(id);
+            if (existsStudentCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student course not found with id: {id}");
+
+            existsStudentCourse.IsDeleted = true;
+            return await _unitOfWork.SaveAsync(cancellation) > 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"An error occured while deleting a student course: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task<bool> ExistsAsync(long id, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var existsStudentCourse = await _unitOfWork.StudentCourse.GetAsync(id);
+            if (existsStudentCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student course not found with id: {id}");
+
+            return true;
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while checking if a student course exists: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task<IEnumerable<StudentCourseForResultDto>> GetAllAsync(CancellationToken cancellation = default)
+    {
+        try
+        {
+            var studentCourses = await _unitOfWork.StudentCourse
+                .GetAllAsync()
+                .Where(x => !x.IsDeleted)
+                .ToListAsync();
+
+            if (!studentCourses.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Student courses not found.");
+
+            return _mapper.Map<IEnumerable<StudentCourseForResultDto>>(studentCourses);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"An error occured while getting all student courses: {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task<StudentCourseForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var studentCourse = await _unitOfWork.StudentCourse.GetAsync(id);
+            if (studentCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student course not found with id: {id}");
+
+            return _mapper.Map<StudentCourseForResultDto>(studentCourse);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while getting a student course by id: {id}. {ex.Message}");
+            throw;
+        }
+    }
+
+    public async Task<bool> UpdateAsync(long id, StudentCourseForUpdateDto studentCourse, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var validationResult = await _validator.ValidateUpdate(studentCourse);
+            if(!validationResult.IsValid)
+                throw new ValidationException(validationResult.Errors);
+
+            var existsStudentCourse = await _unitOfWork.StudentCourse.GetAsync(id);
+            if (existsStudentCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student course not found with id: {id}");
+
+            if(existsStudentCourse.IsDeleted)
+                throw new StatusCodeException(HttpStatusCode.Gone, "This student course has been deleted.");
+
+            var existsStudent = await _unitOfWork.Student.GetAsync(studentCourse.StudentId);
+            if (existsStudent is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Student not found with id: {studentCourse.StudentId}");
+
+            var existsCourse = await _unitOfWork.Course.GetAsync(studentCourse.CourseId);
+            if (existsCourse is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, $"Course not found with id: {studentCourse.CourseId}");
+
+            _mapper.Map(studentCourse, existsStudentCourse);
+            existsStudentCourse.Id = id;
+            existsStudentCourse.UpdatedAt = DateTime.UtcNow.AddHours(5);
+
+            return await _unitOfWork.StudentCourse.UpdateAsync(existsStudentCourse);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while updating a student course: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/EduFlow.Domain/Entities/Courses/Course.cs
+++ b/EduFlow.Domain/Entities/Courses/Course.cs
@@ -1,4 +1,4 @@
-﻿using EduFlow.Domain.Entities.Base;
+﻿    using EduFlow.Domain.Entities.Base;
 using EduFlow.Domain.Entities.Users;
 using EduFlow.Domain.Enums;
 using System.ComponentModel.DataAnnotations.Schema;


### PR DESCRIPTION
- Introduced `DbSet<StudentCourse>` in `AppDbContext` for managing student-course relationships.
- Updated `IUnitOfWork` to include `IStudentCourseRepository`.
- Modified migration files to create the `StudentCourses` table.
- Updated `AppDbContextModelSnapshot` to reflect the new table.
- Added `IStudentCourseRepository` interface for data access.
- Implemented `StudentCourseRepository` for specific data operations.
- Ensured consistent naming for the `StudentCourses` table across files.