### PR TITLE
Initialize StudentCourse lists in Course and Student classes

### DIFF
--- a/EduFlow.BLL/Interfaces/Users/IStudentService.cs
+++ b/EduFlow.BLL/Interfaces/Users/IStudentService.cs
@@ -7,6 +7,7 @@ public interface IStudentService
     Task<IEnumerable<StudentForResultDto>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<StudentForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
     Task<bool> AddAsync(StudentForCreateDto dto, CancellationToken cancellationToken = default);
+    Task<long> AddAndReturnIdAsync(StudentForCreateDto dto, CancellationToken cancellationToken = default);
     Task<bool> UpdateAsync(long id, StudentForUpdateDto dto, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
     Task<StudentForResultDto> GetByPhoneNumberAsync(string phoneNumber, CancellationToken cancellationToken = default);

--- a/EduFlow.Domain/Entities/Courses/Course.cs
+++ b/EduFlow.Domain/Entities/Courses/Course.cs
@@ -20,5 +20,5 @@ public class Course : BaseEntity
     public Category Category { get; set; }
     public List<Teacher> Teachers { get; set; } = new List<Teacher>();
     public List<Group> Groups { get; set; } = new List<Group>();
-    public List<StudentCourse> Students { get; set; }
+    public List<StudentCourse> Students { get; set; } = new List<StudentCourse>();
 }

--- a/EduFlow.Domain/Entities/Users/Student.cs
+++ b/EduFlow.Domain/Entities/Users/Student.cs
@@ -16,7 +16,7 @@ public class Student : BaseEntity
     public string? Address { get; set; }
     [Column("phone_number")]
     public required string PhoneNumber { get; set; }
-    public List<StudentCourse> StudentCourses { get; set; }
+    public List<StudentCourse> StudentCourses { get; set; } = new List<StudentCourse>();
     public List<Payment> Payments { get; set; } = new List<Payment>();
     public List<Group> Groups { get; set; } = new List<Group>();
 }

--- a/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
+++ b/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
@@ -73,6 +73,28 @@ public class StudentController(
         }
     }
 
+    [HttpPost("with-id")]
+    public async Task<IActionResult> AddAndReturnIdAsync([FromBody] StudentForCreateDto dto, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var response = await _service.AddAndReturnIdAsync(dto, cancellation);
+            return Ok(response);
+        }
+        catch (ValidationException ex)
+        {
+            return StatusCode(StatusCodes.Status400BadRequest, ex.Message);
+        }
+        catch (StatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
+
     [HttpDelete("{id:long}")]
     public async Task<IActionResult> DeleteAsync([FromRoute] long id, CancellationToken cancellation = default)
     {


### PR DESCRIPTION
Updated the `Students` property in the `Course` class and the `StudentCourses` property in the `Student` class to ensure they are instantiated as new lists of `StudentCourse` objects upon object creation. This change improves the reliability of these properties by preventing null reference issues.