### PR TITLE
Improve group name retrieval in StudentPage

### DIFF
--- a/EduFlow.BLL/Interfaces/Users/IStudentService.cs
+++ b/EduFlow.BLL/Interfaces/Users/IStudentService.cs
@@ -14,4 +14,5 @@ public interface IStudentService
     Task<IEnumerable<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default);
     Task<IEnumerable<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId, CancellationToken cancellationToken = default); 
     Task<bool> AddStudentByGroupAsync(long studentId, long groupId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<StudentForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default);
 }

--- a/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
@@ -15,5 +15,5 @@ public interface IStudentServer
     Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId);
     Task<List<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId);
     Task<bool> AddStudentByCourseAsync(long studentId, long courseId);
-    Task<List<StudentCourseForResultDto>> GetAllByCourseIdAsync(long courseId);
+    Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId);
 }

--- a/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
@@ -1,4 +1,5 @@
-﻿using EduFlow.BLL.DTOs.Users.Student;
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using EduFlow.BLL.DTOs.Users.Student;
 
 namespace EduFlow.Desktop.Integrated.Servers.Interfaces.Users.Student;
 
@@ -14,4 +15,5 @@ public interface IStudentServer
     Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId);
     Task<List<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId);
     Task<bool> AddStudentByCourseAsync(long studentId, long courseId);
+    Task<List<StudentCourseForResultDto>> GetAllByCourseIdAsync(long courseId);
 }

--- a/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
@@ -1,4 +1,5 @@
-﻿using EduFlow.BLL.DTOs.Users.Student;
+﻿using EduFlow.BLL.DTOs.Courses.StudentCourse;
+using EduFlow.BLL.DTOs.Users.Student;
 using EduFlow.Desktop.Integrated.Api.Auth;
 using EduFlow.Desktop.Integrated.Security;
 using EduFlow.Desktop.Integrated.Servers.Interfaces.Users.Student;
@@ -171,6 +172,31 @@ public class StudentServer : IStudentServer
             return new List<StudentForResultDto>();
         }
     }
+
+    public async Task<List<StudentCourseForResultDto>> GetAllByCourseIdAsync(long courseId)
+    {
+        try
+        {
+            HttpClient client = new HttpClient();
+            var token = IdentitySingelton.GetInstance().Token;
+
+            client.BaseAddress = new Uri($"{AuthApi.BASE_URL}/api/students/{courseId}/course");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var response = await client.GetAsync(client.BaseAddress);
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            List<StudentCourseForResultDto> students = JsonConvert.DeserializeObject<List<StudentCourseForResultDto>>(result)!;
+
+            return students;
+        }
+        catch(Exception ex)
+        {
+            return new List<StudentCourseForResultDto>();
+        }
+    }
+
     public async Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId)
     {
         try

--- a/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
@@ -173,7 +173,7 @@ public class StudentServer : IStudentServer
         }
     }
 
-    public async Task<List<StudentCourseForResultDto>> GetAllByCourseIdAsync(long courseId)
+    public async Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId)
     {
         try
         {
@@ -187,13 +187,13 @@ public class StudentServer : IStudentServer
 
             var result = await response.Content.ReadAsStringAsync();
 
-            List<StudentCourseForResultDto> students = JsonConvert.DeserializeObject<List<StudentCourseForResultDto>>(result)!;
+            List<StudentForResultDto> students = JsonConvert.DeserializeObject<List<StudentForResultDto>>(result)!;
 
             return students;
         }
         catch(Exception ex)
         {
-            return new List<StudentCourseForResultDto>();
+            return new List<StudentForResultDto>();
         }
     }
 

--- a/EduFlow.Desktop.Integrated/Services/Users/Student/IStudentService.cs
+++ b/EduFlow.Desktop.Integrated/Services/Users/Student/IStudentService.cs
@@ -14,4 +14,5 @@ public interface IStudentService
     Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId);
     Task<List<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId);
     Task<bool> AddStudentByCourseAsync(long studentId, long courseId);
+    Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId);
 }

--- a/EduFlow.Desktop.Integrated/Services/Users/Student/StudentService.cs
+++ b/EduFlow.Desktop.Integrated/Services/Users/Student/StudentService.cs
@@ -90,6 +90,19 @@ public class StudentService : IStudentService
         }
     }
 
+    public async Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId)
+    {
+        try
+        {
+            var result = await _server.GetAllByCourseIdAsync(courseId);
+            return result;
+        }
+        catch(Exception ex)
+        {
+            return new List<StudentForResultDto>();
+        }
+    }
+
     public async Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId)
     {
         try

--- a/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml
+++ b/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml
@@ -58,7 +58,7 @@
                           FontSize="14"
                           FontFamily="Jetbrains Mono"
                           SelectionChanged="courseComboBox_SelectionChanged">
-                    <ComboBoxItem Content="Kurslar" IsSelected="True" IsEnabled="False"/>
+                    <ComboBoxItem Content="Barcha" IsSelected="True" IsEnabled="False"/>
                 </ComboBox>
             </StackPanel>
         </Grid>

--- a/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml.cs
@@ -3,6 +3,7 @@ using EduFlow.BLL.DTOs.Users.Teacher;
 using EduFlow.Desktop.Components.StudentForComponents;
 using EduFlow.Desktop.Integrated.Security;
 using EduFlow.Desktop.Integrated.Services.Courses.Category;
+using EduFlow.Desktop.Integrated.Services.Courses.Course;
 using EduFlow.Desktop.Integrated.Services.Users.Student;
 using EduFlow.Desktop.Integrated.Services.Users.Teacher;
 using EduFlow.Desktop.Windows.StudentForWindows;
@@ -23,6 +24,7 @@ public partial class StudentPage : Page
 {
     private readonly IStudentService _service;
     private readonly ITeacherService _teacherService;
+    private readonly ICourseService _courseService;
     private readonly ICategoryService _categoryService;
     private TeacherForResultDto _teacher;
     public StudentPage()
@@ -30,6 +32,7 @@ public partial class StudentPage : Page
         InitializeComponent();
         this._service = new StudentService();
         this._teacherService = new TeacherService();
+        this._courseService = new CourseService();
         this._categoryService = new CategoryService();
     }
 
@@ -67,17 +70,17 @@ public partial class StudentPage : Page
         ShowStudents(students);
     }
 
-    private async Task GetAllCategory()
+    private async Task GetAllCourse()
     {
-        var categories = await Task.Run(async () => await _categoryService.GetAllAsync());
+        var courses = await Task.Run(async () => await _courseService.GetAllAsync());
 
-        if (categories.Any())
+        if (courses.Any())
         {
-            foreach (var category in categories)
+            foreach (var course in courses)
             {
                 ComboBoxItem item = new ComboBoxItem();
-                item.Content = category.Name;
-                item.Tag = category.Id;
+                item.Content = course.Name;
+                item.Tag = course.Id;
                 courseComboBox.Items.Add(item);
             }
         }
@@ -87,16 +90,16 @@ public partial class StudentPage : Page
         }
     }
 
-    private async Task GetAllStudentByCategory()
+    private async Task GetAllStudentByCourse()
     {
-        long categoryId = 0;
+        long courseId = 0;
         studentLoader.Visibility = Visibility.Visible;
 
         if(courseComboBox.SelectedItem is ComboBoxItem selectedComboBoxItem
             && selectedComboBoxItem.Tag != null)
-            categoryId = (long)selectedComboBoxItem.Tag;
+            courseId = (long)selectedComboBoxItem.Tag;
 
-        var students = await Task.Run(async () => await _service.GetAllByCategoryIdAsync(categoryId));
+        var students = await Task.Run(async () => await _service.GetAllByCourseIdAsync(courseId));
         
         ShowStudents(students);
     }
@@ -171,7 +174,7 @@ public partial class StudentPage : Page
         else
         {
             await GetAllStudent();
-            await GetAllCategory();
+            await GetAllCourse();
         }
     }
 
@@ -188,7 +191,7 @@ public partial class StudentPage : Page
     private void courseComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if(isPageLoaded)
-            GetAllStudentByCategory();
+            GetAllStudentByCourse();
     }
 
     private async Task GetStudentByPhoneNumber(string phoneNumber)

--- a/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml.cs
+++ b/EduFlow.Desktop/Pages/StudentForPages/StudentPage.xaml.cs
@@ -122,7 +122,7 @@ public partial class StudentPage : Page
                     student.Age,
                     student.Address,
                     student.PhoneNumber,
-                    student.Groups.First().Name);
+                    student.Groups.Any() ? student.Groups.First().Name : "Yo'q");
 
                 stStudents.Children.Add(component);
                 count++;

--- a/EduFlow.Desktop/Pages/TeacherForPages/TeacherPage.xaml
+++ b/EduFlow.Desktop/Pages/TeacherForPages/TeacherPage.xaml
@@ -83,7 +83,7 @@
                           FontSize="14"
                           FontFamily="Jetbrains Mono"
                           SelectionChanged="courseComboBox_SelectionChanged">
-                    <ComboBoxItem Content="Kurslar" IsSelected="True" IsEnabled="False"/>
+                    <ComboBoxItem Content="Barcha" IsSelected="True" IsEnabled="False"/>
                 </ComboBox>
 
                 <Button x:Name="craeteTeacherBtn"

--- a/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
+++ b/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
@@ -23,11 +23,11 @@ public class StudentController(
             var response = await _service.GetAllAsync(cancellationToken);
             return Ok(response);
         }
-        catch(StatusCodeException ex)
+        catch (StatusCodeException ex)
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -45,7 +45,7 @@ public class StudentController(
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -59,15 +59,15 @@ public class StudentController(
             var response = await _service.AddAsync(dto, cancellation);
             return Ok(response);
         }
-        catch(ValidationException ex)
+        catch (ValidationException ex)
         {
             return StatusCode(StatusCodes.Status400BadRequest, ex.Message);
         }
-        catch(StatusCodeException ex)
+        catch (StatusCodeException ex)
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -103,11 +103,11 @@ public class StudentController(
             var response = await _service.DeleteAsync(id, cancellation);
             return Ok(response);
         }
-        catch(StatusCodeException ex)
+        catch (StatusCodeException ex)
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -121,15 +121,15 @@ public class StudentController(
             var response = await _service.UpdateAsync(id, dto, cancellation);
             return Ok(response);
         }
-        catch(ValidationException ex)
+        catch (ValidationException ex)
         {
             return StatusCode(StatusCodes.Status400BadRequest, ex.Message);
         }
-        catch(StatusCodeException ex)
+        catch (StatusCodeException ex)
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -143,11 +143,11 @@ public class StudentController(
             var response = await _service.GetByPhoneNumberAsync(phoneNumber, cancellation);
             return Ok(response);
         }
-        catch(StatusCodeException ex)
+        catch (StatusCodeException ex)
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }
@@ -201,7 +201,25 @@ public class StudentController(
         {
             return StatusCode((int)ex.StatusCode, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
+
+    [HttpGet("{courseId:long}/course")]
+    public async Task<IActionResult> GetAllByCourseIdAsync([FromRoute] long courseId, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var response = await _service.GetAllByCourseIdAsync(courseId, cancellation);
+            return Ok(response);
+        }
+        catch (StatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
         {
             return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
         }


### PR DESCRIPTION
Updated the logic for retrieving the first group's name from the `student.Groups` collection. The code now checks for the presence of groups before accessing the first group's name, defaulting to "Yo'q" if no groups are available. This change enhances code robustness and prevents potential errors.