### PR TITLE
Refactor attendance DTOs and introduce lesson DTOs

### DIFF
--- a/EduFlow.BLL/Common/Mapping/MappingProfile.cs
+++ b/EduFlow.BLL/Common/Mapping/MappingProfile.cs
@@ -3,6 +3,7 @@ using EduFlow.BLL.DTOs.Courses.Attendance;
 using EduFlow.BLL.DTOs.Courses.Category;
 using EduFlow.BLL.DTOs.Courses.Course;
 using EduFlow.BLL.DTOs.Courses.Group;
+using EduFlow.BLL.DTOs.Courses.Lesson;
 using EduFlow.BLL.DTOs.Courses.StudentCourse;
 using EduFlow.BLL.DTOs.Messages.Message;
 using EduFlow.BLL.DTOs.Payments.Payment;
@@ -78,6 +79,12 @@ public class MappingProfile : Profile
         CreateMap<AttendanceForResultDto, Attendance>();
         CreateMap<AttendanceForCraeteDto, Attendance>();
         CreateMap<AttendanceForUpdateDto, Attendance>();
+
+        /*--------------------------------------Lesson------------------------------------------*/
+        CreateMap<Lesson, LessonForResultDto>();
+        CreateMap<LessonForResultDto, Lesson>();
+        CreateMap<LessonForCreateDto, Lesson>();
+        CreateMap<LessonForUpdateDto, Lesson>();
 
         /*--------------------------------------Message------------------------------------------*/
         CreateMap<Message, MessageForResultDto>();

--- a/EduFlow.BLL/Common/Validators/Courses/Attendance/AttendanceForCreateValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Attendance/AttendanceForCreateValidator.cs
@@ -10,8 +10,8 @@ public class AttendanceForCreateValidator : AbstractValidator<AttendanceForCraet
         RuleFor(x => x.StudentId)
             .GreaterThan(0).WithMessage("O'quvchi Id si 0 dan katta bo'lishi kerak");
 
-        RuleFor(x => x.GroupId)
-            .GreaterThan(0).WithMessage("Kurs Id si 0 dan katta bo'lishi kerak");
+        RuleFor(x => x.LessonId)
+            .GreaterThan(0).WithMessage("Dars Id si 0 dan katta bo'lishi kerak");
 
         RuleFor(x => x.Date)
             .NotNull().WithMessage("Sana bo'lishi shart");

--- a/EduFlow.BLL/Common/Validators/Courses/Attendance/AttendanceForUpdateValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Attendance/AttendanceForUpdateValidator.cs
@@ -10,8 +10,8 @@ public class AttendanceForUpdateValidator : AbstractValidator<AttendanceForUpdat
         RuleFor(x => x.StudentId)
             .GreaterThan(0).WithMessage("O'quvchi Id si 0 dan katta bo'lishi kerak");
 
-        RuleFor(x => x.GroupId)
-            .GreaterThan(0).WithMessage("Kurs Id si 0 dan katta bo'lishi kerak");
+        RuleFor(x => x.LessonId)
+            .GreaterThan(0).WithMessage("Dars Id si 0 dan katta bo'lishi kerak");
 
         RuleFor(x => x.Date)
             .NotNull().WithMessage("Sana bo'lishi shart");

--- a/EduFlow.BLL/Common/Validators/Courses/Interfaces/ILessonValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Interfaces/ILessonValidator.cs
@@ -1,0 +1,10 @@
+﻿using EduFlow.BLL.DTOs.Courses.Lesson;
+using FluentValidation.Results;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Interfaces;
+
+public interface ILessonValidator
+{
+    Task<ValidationResult> ValidateCraete(LessonForCreateDto dto);
+    Task<ValidationResult> ValidateUpdate(LessonForUpdateDto dto);
+}

--- a/EduFlow.BLL/Common/Validators/Courses/Lesson/LessonForCraeteValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Lesson/LessonForCraeteValidator.cs
@@ -1,0 +1,18 @@
+﻿using EduFlow.BLL.DTOs.Courses.Lesson;
+using FluentValidation;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Lesson;
+
+public class LessonForCraeteValidator : AbstractValidator<LessonForCreateDto>
+{
+    public LessonForCraeteValidator()
+    {
+        RuleFor(x => x.LessonNumber)
+            .NotEmpty().WithMessage("Dars raqami bo'sh bo'lmasligi kerak")
+            .GreaterThan(0).WithMessage("Dars raqami 0 dan katta bo'lishi kerak");
+
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Guruh ID bo'sh bo'lmasligi kerak")
+            .GreaterThan(0).WithMessage("Guruh ID 0 dan katta bo'lishi kerak");
+    }
+}

--- a/EduFlow.BLL/Common/Validators/Courses/Lesson/LessonForUpdateValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Lesson/LessonForUpdateValidator.cs
@@ -1,0 +1,18 @@
+﻿using EduFlow.BLL.DTOs.Courses.Lesson;
+using FluentValidation;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Lesson;
+
+public class LessonForUpdateValidator : AbstractValidator<LessonForUpdateDto>
+{
+    public LessonForUpdateValidator()
+    {
+        RuleFor(x => x.LessonNumber)
+            .NotEmpty().WithMessage("Dars raqami bo'sh bo'lmasligi kerak")
+            .GreaterThan(0).WithMessage("Dars raqami 0 dan katta bo'lishi kerak");
+
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Guruh ID bo'sh bo'lmasligi kerak")
+            .GreaterThan(0).WithMessage("Guruh ID 0 dan katta bo'lishi kerak");
+    }
+}

--- a/EduFlow.BLL/Common/Validators/Courses/Services/LessonValidator.cs
+++ b/EduFlow.BLL/Common/Validators/Courses/Services/LessonValidator.cs
@@ -1,0 +1,19 @@
+﻿using EduFlow.BLL.Common.Validators.Courses.Interfaces;
+using EduFlow.BLL.DTOs.Courses.Lesson;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace EduFlow.BLL.Common.Validators.Courses.Services;
+
+public class LessonValidator(
+    IValidator<LessonForCreateDto> craeteValidator,
+    IValidator<LessonForUpdateDto> updateValidator) : ILessonValidator
+{
+    private readonly IValidator<LessonForCreateDto> _createValidator = craeteValidator;
+    private readonly IValidator<LessonForUpdateDto> _updateValidator = updateValidator;
+    public async Task<ValidationResult> ValidateCraete(LessonForCreateDto dto)
+        => await _createValidator.ValidateAsync(dto);
+
+    public async Task<ValidationResult> ValidateUpdate(LessonForUpdateDto dto)
+        => await _updateValidator.ValidateAsync(dto);
+}

--- a/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForCraeteDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForCraeteDto.cs
@@ -3,7 +3,7 @@
 public class AttendanceForCraeteDto
 {
     public long StudentId { get; set; }
-    public long GroupId { get; set; }
+    public long LessonId { get; set; }
     public DateTime Date { get; set; }
     public bool IsActived { get; set; }
 }

--- a/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForResultDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForResultDto.cs
@@ -10,8 +10,8 @@ public class AttendanceForResultDto
     public DateTime UpdatedAt { get; set; }
     public long StudentId { get; set; }
     public Student Student { get; set; }
-    public long GroupId { get; set; }
-    public Et.Group Group { get; set; }
+    public long LessonId { get; set; }
+    public Et.Lesson Lesson { get; set; }
     public DateTime Date { get; set; }
     public bool IsActived { get; set; }
 }

--- a/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForUpdateDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Attendance/AttendanceForUpdateDto.cs
@@ -3,7 +3,7 @@
 public class AttendanceForUpdateDto
 {
     public long StudentId { get; set; }
-    public long GroupId { get; set; }
+    public long LessonId { get; set; }
     public DateTime Date { get; set; }
     public bool IsActived { get; set; }
 }

--- a/EduFlow.BLL/DTOs/Courses/Lesson/LessonForCreateDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Lesson/LessonForCreateDto.cs
@@ -1,0 +1,9 @@
+﻿namespace EduFlow.BLL.DTOs.Courses.Lesson;
+
+public class LessonForCreateDto
+{
+    public string? Name { get; set; }
+    public int LessonNumber { get; set; }
+    public DateTime Date { get; set; }
+    public long GroupId { get; set; }
+}

--- a/EduFlow.BLL/DTOs/Courses/Lesson/LessonForResultDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Lesson/LessonForResultDto.cs
@@ -1,0 +1,13 @@
+﻿using Et = EduFlow.Domain.Entities.Courses;
+
+namespace EduFlow.BLL.DTOs.Courses.Lesson;
+
+public class LessonForResultDto
+{
+    public long Id { get; set; }
+    public string? Name { get; set; }
+    public int LessonNumber { get; set; }
+    public DateTime Date { get; set; }
+    public long GroupId { get; set; }
+    public List<Et.Attendance> Attendances { get; set; }
+}

--- a/EduFlow.BLL/DTOs/Courses/Lesson/LessonForUpdateDto.cs
+++ b/EduFlow.BLL/DTOs/Courses/Lesson/LessonForUpdateDto.cs
@@ -1,0 +1,9 @@
+﻿namespace EduFlow.BLL.DTOs.Courses.Lesson;
+
+public class LessonForUpdateDto
+{
+    public string? Name { get; set; }
+    public int LessonNumber { get; set; }
+    public DateTime Date { get; set; }
+    public long GroupId { get; set; }
+}

--- a/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
@@ -8,7 +8,7 @@ public interface IAttendanceService
     Task<AttendanceForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
     Task<bool> AddAsync(AttendanceForCraeteDto dto, CancellationToken cancellationToken = default);
     Task<bool> UpdateAsync(long id, AttendanceForUpdateDto dto, CancellationToken cancellationToken = default);
-    Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default);
+    //Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
     Task<IEnumerable<AttendanceForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default);
     Task<IEnumerable<AttendanceForResultDto>> GetAllByLessonIdAsync(long lessonId, CancellationToken cancellationToken = default);

--- a/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/IAttendanceService.cs
@@ -8,7 +8,8 @@ public interface IAttendanceService
     Task<AttendanceForResultDto> GetByIdAsync(long id, CancellationToken cancellationToken = default);
     Task<bool> AddAsync(AttendanceForCraeteDto dto, CancellationToken cancellationToken = default);
     Task<bool> UpdateAsync(long id, AttendanceForUpdateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(long id, CancellationToken cancellationToken = default);
     Task<IEnumerable<AttendanceForResultDto>> GetAllByStudentIdAsync(long studentId, CancellationToken cancellationToken = default);
-    Task<IEnumerable<AttendanceForResultDto>> GetAllByGroupIdAsync(long groupId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AttendanceForResultDto>> GetAllByLessonIdAsync(long lessonId, CancellationToken cancellationToken = default);
 }

--- a/EduFlow.BLL/Interfaces/Courses/ILessonService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/ILessonService.cs
@@ -7,6 +7,6 @@ public interface ILessonService
     Task<IEnumerable<LessonForResultDto>> GetAllAsync(CancellationToken cancellation = default);
     Task<LessonForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default);
     Task<bool> AddAsync(LessonForCreateDto lesson, CancellationToken cancellation = default);
-    Task<bool> UpdateAsync(LessonForUpdateDto lesson, CancellationToken cancellation = default);
+    Task<bool> UpdateAsync(long id, LessonForUpdateDto lesson, CancellationToken cancellation = default);
     Task<bool> DeleteAsync(long id, CancellationToken cancellation = default);
 }

--- a/EduFlow.BLL/Interfaces/Courses/ILessonService.cs
+++ b/EduFlow.BLL/Interfaces/Courses/ILessonService.cs
@@ -1,0 +1,12 @@
+﻿using EduFlow.BLL.DTOs.Courses.Lesson;
+
+namespace EduFlow.BLL.Interfaces.Courses;
+
+public interface ILessonService
+{
+    Task<IEnumerable<LessonForResultDto>> GetAllAsync(CancellationToken cancellation = default);
+    Task<LessonForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default);
+    Task<bool> AddAsync(LessonForCreateDto lesson, CancellationToken cancellation = default);
+    Task<bool> UpdateAsync(LessonForUpdateDto lesson, CancellationToken cancellation = default);
+    Task<bool> DeleteAsync(long id, CancellationToken cancellation = default);
+}

--- a/EduFlow.BLL/Services/Courses/AttendanceService.cs
+++ b/EduFlow.BLL/Services/Courses/AttendanceService.cs
@@ -182,48 +182,48 @@ public class AttendanceService(
         }
     }
 
-    public async Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (!dtos.Any())
-                throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
+    //public async Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default)
+    //{
+    //    try
+    //    {
+    //        if (!dtos.Any())
+    //            throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
 
-            var existsAttendances = await _unitOfWork.Attendance
-                .GetAllAsync()
-                .Where(x => dtos.Select(x => x.Id).Contains(x.Id))
-                .ToListAsync();
+    //        var existsAttendances = await _unitOfWork.Attendance
+    //            .GetAllAsync()
+    //            .Where(x => dtos.Select(x => x.Id).Contains(x.Id))
+    //            .ToListAsync();
 
-            if (!existsAttendances.Any())
-                throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
+    //        if (!existsAttendances.Any())
+    //            throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
 
-            var existsLessons = await _unitOfWork.Lesson
-                .GetAllAsync()
-                .Where(x => dtos.Select(x => x.LessonId).Contains(x.Id))
-                .ToListAsync();
+    //        var existsLessons = await _unitOfWork.Lesson
+    //            .GetAllAsync()
+    //            .Where(x => dtos.Select(x => x.LessonId).Contains(x.Id))
+    //            .ToListAsync();
 
-            if (!existsLessons.Any())
-                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
+    //        if (!existsLessons.Any())
+    //            throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
 
-            var savedAttendances = _mapper.Map<List<Attendance>>(dtos);
-            foreach (var attendance in existsAttendances)
-            {
-                var updatedAttendance = savedAttendances.FirstOrDefault(x => x.Id == attendance.Id);
-                if (updatedAttendance != null)
-                {
-                    attendance.IsActived = updatedAttendance.IsActived;
-                    attendance.UpdatedAt = DateTime.UtcNow.AddHours(5);
-                }
-            }
+    //        var savedAttendances = _mapper.Map<List<Attendance>>(dtos);
+    //        foreach (var attendance in existsAttendances)
+    //        {
+    //            var updatedAttendance = savedAttendances.FirstOrDefault(x => x.Id == attendance.Id);
+    //            if (updatedAttendance != null)
+    //            {
+    //                attendance.IsActived = updatedAttendance.IsActived;
+    //                attendance.UpdatedAt = DateTime.UtcNow.AddHours(5);
+    //            }
+    //        }
 
-            var result = await _unitOfWork.Attendance.UpdateRangeAsync(existsAttendances);
+    //        var result = await _unitOfWork.Attendance.UpdateRangeAsync(existsAttendances);
 
-            return result;
-        }
-        catch(Exception ex)
-        {
-            _logger.LogError($"An error occured while update range attendance. {ex}");
-            throw;
-        }
-    }
+    //        return result;
+    //    }
+    //    catch(Exception ex)
+    //    {
+    //        _logger.LogError($"An error occured while update range attendance. {ex}");
+    //        throw;
+    //    }
+    //}
 }

--- a/EduFlow.BLL/Services/Courses/AttendanceService.cs
+++ b/EduFlow.BLL/Services/Courses/AttendanceService.cs
@@ -30,9 +30,9 @@ public class AttendanceService(
             if (!validationResult.IsValid)
                 throw new ValidationException(validationResult.Errors);
 
-            var existsCourse = await _unitOfWork.Course.GetAsync(dto.GroupId);
-            if(existsCourse is null)
-                throw new StatusCodeException(HttpStatusCode.NotFound, "Course not found.");
+            var existsLesson = await _unitOfWork.Lesson.GetAsync(dto.LessonId);
+            if(existsLesson is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
 
             var existsStudent = await _unitOfWork.Student.GetAsync(dto.StudentId);
             if (existsStudent is null)
@@ -108,13 +108,13 @@ public class AttendanceService(
         }
     }
 
-    public async Task<IEnumerable<AttendanceForResultDto>> GetAllByGroupIdAsync(long groupId, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<AttendanceForResultDto>> GetAllByLessonIdAsync(long lessonId, CancellationToken cancellationToken = default)
     {
         try
         {
             var attendances = await _unitOfWork.Attendance
                 .GetAllAsync()
-                //.Where(x => x.GroupId == groupId)
+                .Where(x => x.LessonId == lessonId)
                 .ToListAsync();
 
             if (!attendances.Any())
@@ -124,7 +124,7 @@ public class AttendanceService(
         }
         catch(Exception ex)
         {
-            _logger.LogError($"An error occured while get all attendance by course id: {groupId}. {ex}");
+            _logger.LogError($"An error occured while get all attendance by course id: {lessonId}. {ex}");
             throw;
         }
     }
@@ -161,9 +161,9 @@ public class AttendanceService(
             if (existsAttendance is null)
                 throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
 
-            var existsCourse = await _unitOfWork.Course.GetAsync(dto.GroupId);
-            if (existsCourse is null)
-                throw new StatusCodeException(HttpStatusCode.NotFound, "Course not found.");
+            var existsLesson = await _unitOfWork.Lesson.GetAsync(dto.LessonId);
+            if (existsLesson is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
 
             var existsStudent = await _unitOfWork.Student.GetAsync(dto.StudentId);
             if (existsStudent is null)
@@ -178,6 +178,51 @@ public class AttendanceService(
         catch(Exception ex)
         {
             _logger.LogError($"An error occured while update attendance id: {id}. {ex}");
+            throw;
+        }
+    }
+
+    public async Task<bool> UpdateRangeAsync(List<AttendanceForUpdateDto> dtos, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!dtos.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
+
+            var existsAttendances = await _unitOfWork.Attendance
+                .GetAllAsync()
+                .Where(x => dtos.Select(x => x.Id).Contains(x.Id))
+                .ToListAsync();
+
+            if (!existsAttendances.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Attendance not found.");
+
+            var existsLessons = await _unitOfWork.Lesson
+                .GetAllAsync()
+                .Where(x => dtos.Select(x => x.LessonId).Contains(x.Id))
+                .ToListAsync();
+
+            if (!existsLessons.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
+
+            var savedAttendances = _mapper.Map<List<Attendance>>(dtos);
+            foreach (var attendance in existsAttendances)
+            {
+                var updatedAttendance = savedAttendances.FirstOrDefault(x => x.Id == attendance.Id);
+                if (updatedAttendance != null)
+                {
+                    attendance.IsActived = updatedAttendance.IsActived;
+                    attendance.UpdatedAt = DateTime.UtcNow.AddHours(5);
+                }
+            }
+
+            var result = await _unitOfWork.Attendance.UpdateRangeAsync(existsAttendances);
+
+            return result;
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while update range attendance. {ex}");
             throw;
         }
     }

--- a/EduFlow.BLL/Services/Courses/LessonService.cs
+++ b/EduFlow.BLL/Services/Courses/LessonService.cs
@@ -1,41 +1,138 @@
 ﻿using AutoMapper;
+using EduFlow.BLL.Common.Exceptions;
+using EduFlow.BLL.Common.Validators.Courses.Interfaces;
 using EduFlow.BLL.DTOs.Courses.Lesson;
 using EduFlow.BLL.Interfaces.Courses;
 using EduFlow.DAL.Interfaces;
+using EduFlow.Domain.Entities.Courses;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Net;
 
 namespace EduFlow.BLL.Services.Courses;
 
 public class LessonService(
     IUnitOfWork unitOfWork,
     IMapper mapper,
-    ILogger<LessonService> logger) : ILessonService
+    ILogger<LessonService> logger,
+    ILessonValidator validator) : ILessonService
 {
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
     private readonly IMapper _mapper = mapper;
     private readonly ILogger<LessonService> _logger = logger;
-    public Task<bool> AddAsync(LessonForCreateDto lesson, CancellationToken cancellation = default)
+    private readonly ILessonValidator _validator = validator;
+    public async Task<bool> AddAsync(LessonForCreateDto lesson, CancellationToken cancellation = default)
     {
-        throw new NotImplementedException();
+        try
+        {
+            var validationResult = await _validator.ValidateCraete(lesson);
+            if (validationResult.IsValid)
+                throw new ValidationException(validationResult.Errors);
+
+            var existsGroup = await _unitOfWork.Course.GetAsync(lesson.GroupId);
+            if (existsGroup is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Group not found.");
+
+            var savedLesson = _mapper.Map<Lesson>(lesson);
+
+            return await _unitOfWork.Lesson.AddConfirmAsync(savedLesson);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while adding the lesson. {ex}");
+            throw;
+        }
     }
 
-    public Task<bool> DeleteAsync(long id, CancellationToken cancellation = default)
+    public async Task<bool> DeleteAsync(long id, CancellationToken cancellation = default)
     {
-        throw new NotImplementedException();
+        try
+        {
+            var existsLesson = await _unitOfWork.Lesson.GetAsync(id);
+            if (existsLesson is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
+
+            if (existsLesson.IsDeleted)
+                throw new StatusCodeException(HttpStatusCode.Gone, "This lesson has been deleted.");
+
+            existsLesson.IsDeleted = true;
+            return await _unitOfWork.SaveAsync(cancellation) > 0;
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while delete the lesson id: {id}. {ex}");
+            throw;
+        }
     }
 
-    public Task<IEnumerable<LessonForResultDto>> GetAllAsync(CancellationToken cancellation = default)
+    public async Task<IEnumerable<LessonForResultDto>> GetAllAsync(CancellationToken cancellation = default)
     {
-        throw new NotImplementedException();
+        try
+        {
+            var lessons = await _unitOfWork.Lesson.GetAllFullInformation()
+                .ToListAsync(cancellation);
+
+            if (!lessons.Any())
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lessons not found.");
+
+            return _mapper.Map<IEnumerable<LessonForResultDto>>(lessons);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while get all by lesson. {ex}");
+            throw;
+        }
     }
 
-    public Task<LessonForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default)
+    public async Task<LessonForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default)
     {
-        throw new NotImplementedException();
+        try
+        {
+            var lesson = await _unitOfWork.Lesson
+                .GetAllAsync()
+                .Where(x => x.Id == id && !x.IsDeleted)
+                .FirstOrDefaultAsync(cancellation);
+
+            if (lesson is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
+
+            return _mapper.Map<LessonForResultDto>(lesson);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"An error occured while get by lesson id: {id}. {ex}");
+            throw;
+        }
     }
 
-    public Task<bool> UpdateAsync(LessonForUpdateDto lesson, CancellationToken cancellation = default)
+    public async Task<bool> UpdateAsync(long id, LessonForUpdateDto lesson, CancellationToken cancellation = default)
     {
-        throw new NotImplementedException();
+        try
+        {
+            var validationResult = await _validator.ValidateUpdate(lesson);
+            if (validationResult.IsValid)
+                throw new ValidationException(validationResult.Errors);
+
+            var existsLesson = await _unitOfWork.Lesson.GetAllAsync()
+                .Where(x => x.Id == id && !x.IsDeleted)
+                .FirstOrDefaultAsync(cancellation);
+
+            if (existsLesson is null)
+                throw new StatusCodeException(HttpStatusCode.NotFound, "Lesson not found.");
+
+            if (existsLesson.IsDeleted)
+                throw new StatusCodeException(HttpStatusCode.Gone, "This lesson has been deleted.");
+
+            var savedLesson = _mapper.Map(lesson, existsLesson);
+            savedLesson.Id = id;
+
+            return await _unitOfWork.Lesson.UpdateAsync(savedLesson);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError($"An error occured while update the lesson. {ex}");
+            throw;
+        }
     }
 }

--- a/EduFlow.BLL/Services/Courses/LessonService.cs
+++ b/EduFlow.BLL/Services/Courses/LessonService.cs
@@ -1,0 +1,41 @@
+﻿using AutoMapper;
+using EduFlow.BLL.DTOs.Courses.Lesson;
+using EduFlow.BLL.Interfaces.Courses;
+using EduFlow.DAL.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace EduFlow.BLL.Services.Courses;
+
+public class LessonService(
+    IUnitOfWork unitOfWork,
+    IMapper mapper,
+    ILogger<LessonService> logger) : ILessonService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IMapper _mapper = mapper;
+    private readonly ILogger<LessonService> _logger = logger;
+    public Task<bool> AddAsync(LessonForCreateDto lesson, CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> DeleteAsync(long id, CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<LessonForResultDto>> GetAllAsync(CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<LessonForResultDto> GetByIdAsync(long id, CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> UpdateAsync(LessonForUpdateDto lesson, CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EduFlow.WebApi/Configurations/LayerConfiguration.cs
+++ b/EduFlow.WebApi/Configurations/LayerConfiguration.cs
@@ -3,6 +3,7 @@ using EduFlow.BLL.Common.Validators.Courses.Course;
 using EduFlow.BLL.Common.Validators.Courses.Group;
 using EduFlow.BLL.Common.Validators.Courses.Interface;
 using EduFlow.BLL.Common.Validators.Courses.Interfaces;
+using EduFlow.BLL.Common.Validators.Courses.Lesson;
 using EduFlow.BLL.Common.Validators.Courses.Services;
 using EduFlow.BLL.Common.Validators.Courses.StudentCourse;
 using EduFlow.BLL.Common.Validators.Messages.Interfaces;
@@ -20,6 +21,7 @@ using EduFlow.BLL.Common.Validators.Users.User;
 using EduFlow.BLL.DTOs.Courses.Attendance;
 using EduFlow.BLL.DTOs.Courses.Course;
 using EduFlow.BLL.DTOs.Courses.Group;
+using EduFlow.BLL.DTOs.Courses.Lesson;
 using EduFlow.BLL.DTOs.Courses.StudentCourse;
 using EduFlow.BLL.DTOs.Messages.Message;
 using EduFlow.BLL.DTOs.Payments.Payment;
@@ -92,6 +94,7 @@ public static class LayerConfiguration
         services.AddScoped<ICategoryRepository, CategoryRepository>();
         services.AddScoped<IAttendanceRepository, AttendanceRepository>();
         services.AddScoped<IStudentCourseRepository, StudentCourseRepository>();
+        services.AddScoped<ILessonRepository, LessonRepository>();
 
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<ITeacherRepository, TeacherRepository>();
@@ -118,6 +121,7 @@ public static class LayerConfiguration
         services.AddScoped<ICategoryService, CategoryService>();
         services.AddScoped<IAttendanceService, AttendanceService>();
         services.AddScoped<IStudentCourseService, StudentCourseService>();
+        services.AddScoped<ILessonService, LessonService>();
 
         services.AddScoped<IPaymentService, PaymentService>();
         services.AddScoped<IRegistryService, RegistryService>();
@@ -138,6 +142,7 @@ public static class LayerConfiguration
         services.AddTransient<IGroupValidator, GroupValidator>();
         services.AddTransient<IAttendanceValidator, AttendanceValidator>();
         services.AddTransient<IStudentCourseValidator, StudentCourseValidator>();
+        services.AddTransient<ILessonValidator, LessonValidator>();
 
         services.AddTransient<IPaymentValidator, PaymentValidator>();
         services.AddTransient<IRegistryValidator, RegistryValidator>();
@@ -169,6 +174,9 @@ public static class LayerConfiguration
 
         services.AddTransient<IValidator<AttendanceForCraeteDto>, AttendanceForCreateValidator>();
         services.AddTransient<IValidator<AttendanceForUpdateDto>, AttendanceForUpdateValidator>();
+
+        services.AddTransient<IValidator<LessonForCreateDto>, LessonForCraeteValidator>();
+        services.AddTransient<IValidator<LessonForUpdateDto>, LessonForUpdateValidator>();
 
         services.AddTransient<IValidator<StudentCourseForCreateDto>, StudentCourseForCreateValidator>();
         services.AddTransient<IValidator<StudentCourseForUpdateDto>, StudentCourseForUpdateValidator>();

--- a/EduFlow.WebApi/Controllers/Common/Courses/AttendanceController.cs
+++ b/EduFlow.WebApi/Controllers/Common/Courses/AttendanceController.cs
@@ -130,12 +130,12 @@ public class AttendanceController(
         }
     }
 
-    [HttpGet("{groupId:long}/group")]
-    public async Task<IActionResult> GetAllByGroupIdAsync([FromRoute] long groupId, CancellationToken cancellation = default)
+    [HttpGet("{lessonId:long}/lesson")]
+    public async Task<IActionResult> GetAllByGroupIdAsync([FromRoute] long lessonId, CancellationToken cancellation = default)
     {
         try
         {
-            var response = await _service.GetAllByGroupIdAsync(groupId, cancellation);
+            var response = await _service.GetAllByLessonIdAsync(lessonId, cancellation);
             return Ok(response);
         }
         catch(StatusCodeException ex)


### PR DESCRIPTION
Updated `AttendanceForCraeteDto`, `AttendanceForResultDto`, and `AttendanceForUpdateDto` to replace `GroupId` with `LessonId`, shifting focus to lessons. Added new classes `LessonForCreateDto`, `LessonForResultDto`, and `LessonForUpdateDto` to encapsulate lesson details, including properties like `Name`, `LessonNumber`, and `Date`. Defined a new namespace for lesson-related classes as `EduFlow.BLL.DTOs.Courses.Lesson`.