### PR TITLE
Update date parsing in AttendanceForUpdateRangeDto

### DIFF
--- a/EduFlow.Desktop/Components/LessonForComponents/LessonForAttendanceComponent.xaml.cs
+++ b/EduFlow.Desktop/Components/LessonForComponents/LessonForAttendanceComponent.xaml.cs
@@ -120,7 +120,8 @@ public partial class LessonForAttendanceComponent : UserControl
                     Id = long.Parse(checkBox.Tag.ToString()), 
                     StudentId = attendance.StudentId,
                     LessonId = lesson.Id,
-                    Date = DateTime.ParseExact(tbDate.Text, "dd/MM/yyyy", CultureInfo.InvariantCulture),
+                    //Date = DateTime.ParseExact(tbDate.Text, "dd/MM/yyyy", CultureInfo.InvariantCulture)
+                    Date = DateTime.Parse(tbDate.Text, new CultureInfo("en-GB")),
                     IsActived = attendance.IsActived
                 });
             }


### PR DESCRIPTION
Changed the assignment of the `Date` property to use `DateTime.Parse` with `CultureInfo("en-GB")` instead of `DateTime.ParseExact` with the format "dd/MM/yyyy". This may impact how dates are processed based on input format.