### PR TITLE
Add UpdateStudentByGroupAsync method for student status

### DIFF
--- a/EduFlow.BLL/Interfaces/Users/IStudentService.cs
+++ b/EduFlow.BLL/Interfaces/Users/IStudentService.cs
@@ -1,4 +1,5 @@
 ﻿using EduFlow.BLL.DTOs.Users.Student;
+using EduFlow.Domain.Enums;
 
 namespace EduFlow.BLL.Interfaces.Users;
 
@@ -14,6 +15,7 @@ public interface IStudentService
     Task<IEnumerable<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId, CancellationToken cancellationToken = default);
     Task<IEnumerable<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId, CancellationToken cancellationToken = default); 
     Task<bool> AddStudentByGroupAsync(long studentId, long groupId, CancellationToken cancellationToken = default);
+    Task<bool> UpdateStudentByGroupAsync(long id, long groupId, Status status, CancellationToken cancellationToken = default);
     Task<IEnumerable<StudentForResultDto>> GetAllByCourseIdAsync(long courseId, CancellationToken cancellationToken = default);
     Task<IEnumerable<StudentForResultDto>> FilterAsync(StudentForFilterDto dto, CancellationToken cancellation = default);
 }

--- a/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Interfaces/Users/Student/IStudentServer.cs
@@ -1,4 +1,5 @@
 ﻿using EduFlow.BLL.DTOs.Users.Student;
+using EduFlow.Domain.Enums;
 
 namespace EduFlow.Desktop.Integrated.Servers.Interfaces.Users.Student;
 
@@ -14,6 +15,7 @@ public interface IStudentServer
     Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId);
     Task<List<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId);
     Task<bool> AddStudentByCourseAsync(long studentId, long courseId);
+    Task<bool> UpdateStudentByGroupAsync(long id, long groupId, Status status);
     Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId);
     Task<List<StudentForResultDto>> FilterAsync(StudentForFilterDto dto);
 }

--- a/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
+++ b/EduFlow.Desktop.Integrated/Servers/Repositories/Users/Student/StudentServer.cs
@@ -2,6 +2,7 @@
 using EduFlow.Desktop.Integrated.Api.Auth;
 using EduFlow.Desktop.Integrated.Security;
 using EduFlow.Desktop.Integrated.Servers.Interfaces.Users.Student;
+using EduFlow.Domain.Enums;
 using Newtonsoft.Json;
 using System.Net.Http.Headers;
 using System.Text;
@@ -321,6 +322,37 @@ public class StudentServer : IStudentServer
             var response = await client.SendAsync(request);
 
             if (response.IsSuccessStatusCode)
+                return true;
+            else
+                return false;
+        }
+        catch(Exception ex)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> UpdateStudentByGroupAsync(long id, long groupId, Status status)
+    {
+        try
+        {
+            HttpClient client = new HttpClient();
+            var token = IdentitySingelton.GetInstance().Token;
+
+            client.BaseAddress = new Uri($"{AuthApi.BASE_URL}/api/students/{id}/group/{groupId}");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var request = new HttpRequestMessage(HttpMethod.Put, client.BaseAddress)
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(status),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+
+            if(response.IsSuccessStatusCode)
                 return true;
             else
                 return false;

--- a/EduFlow.Desktop.Integrated/Services/Users/Student/IStudentService.cs
+++ b/EduFlow.Desktop.Integrated/Services/Users/Student/IStudentService.cs
@@ -1,4 +1,5 @@
 ﻿using EduFlow.BLL.DTOs.Users.Student;
+using EduFlow.Domain.Enums;
 
 namespace EduFlow.Desktop.Integrated.Services.Users.Student;
 
@@ -14,6 +15,7 @@ public interface IStudentService
     Task<List<StudentForResultDto>> GetAllByTeacherIdAsync(long teacherId);
     Task<List<StudentForResultDto>> GetAllByCategoryIdAsync(long categoryId);
     Task<bool> AddStudentByCourseAsync(long studentId, long courseId);
+    Task<bool> UpdateStudentByGroupAsync(long studentId, long groupId, Status status);
     Task<List<StudentForResultDto>> GetAllByCourseIdAsync(long courseId);
     Task<List<StudentForResultDto>> FilterAsync(StudentForFilterDto dto);
 }

--- a/EduFlow.Desktop.Integrated/Services/Users/Student/StudentService.cs
+++ b/EduFlow.Desktop.Integrated/Services/Users/Student/StudentService.cs
@@ -1,6 +1,7 @@
 ﻿using EduFlow.BLL.DTOs.Users.Student;
 using EduFlow.Desktop.Integrated.Servers.Interfaces.Users.Student;
 using EduFlow.Desktop.Integrated.Servers.Repositories.Users.Student;
+using EduFlow.Domain.Enums;
 
 namespace EduFlow.Desktop.Integrated.Services.Users.Student;
 
@@ -160,6 +161,19 @@ public class StudentService : IStudentService
         try
         {
             var result = await _server.UpdateAsync(id, dto);
+            return result;
+        }
+        catch(Exception ex)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> UpdateStudentByGroupAsync(long studentId, long groupId, Status status)
+    {
+        try
+        {
+            var result = await _server.UpdateStudentByGroupAsync(studentId, groupId, status);
             return result;
         }
         catch(Exception ex)

--- a/EduFlow.Desktop/Components/StudentForComponents/StudentForAttendanceComponent.xaml.cs
+++ b/EduFlow.Desktop/Components/StudentForComponents/StudentForAttendanceComponent.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using EduFlow.Desktop.Integrated.Services.Courses.Group;
+using EduFlow.Desktop.Integrated.Services.Users.Student;
 using EduFlow.Domain.Entities.Users;
 using EduFlow.Domain.Enums;
 using System.Windows;

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
@@ -192,7 +192,7 @@ public partial class GroupForViewWindow : Window
                     student.Id,
                     count,
                     student.Fullname,
-                    EnrollmentStatus.Active, //keyinroq static emas apidan olamiz
+                    EnrollmentStatus.Active,
                     this.Id);
 
                 component.OnDelete = async () =>

--- a/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
+++ b/EduFlow.WebApi/Controllers/Common/Users/StudentController.cs
@@ -1,6 +1,7 @@
 ﻿using EduFlow.BLL.Common.Exceptions;
 using EduFlow.BLL.DTOs.Users.Student;
 using EduFlow.BLL.Interfaces.Users;
+using EduFlow.Domain.Enums;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -231,6 +232,24 @@ public class StudentController(
         try
         {
             var response = await _service.FilterAsync(dto, cancellation);
+            return Ok(response);
+        }
+        catch (StatusCodeException ex)
+        {
+            return StatusCode((int)ex.StatusCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+        }
+    }
+
+    [HttpPut("{id:long}/group/{groupId:long}")]
+    public async Task<IActionResult> UpdateStudentByGroupAsync([FromRoute] long id, [FromRoute] long groupId, [FromBody] Status status, CancellationToken cancellation = default)
+    {
+        try
+        {
+            var response = await _service.UpdateStudentByGroupAsync(id, groupId, status, cancellation);
             return Ok(response);
         }
         catch (StatusCodeException ex)


### PR DESCRIPTION
This commit introduces the `UpdateStudentByGroupAsync` method across multiple files, enabling the update of a student's status within a specific group. The method has been added to the `IStudentService` and `IStudentServer` interfaces, along with their implementations in `StudentService` and `StudentServer`.

Error handling is included for scenarios where the student or group is not found. The `Status` enum from `EduFlow.Domain.Enums` has been imported to support this functionality. Additionally, the method is exposed in the `StudentController` to handle HTTP PUT requests, allowing clients to update a student's group status via the API.

These changes enhance the student management capabilities of the application, ensuring consistency across service, server, and API layers.