### PR TITLE
Add GroupForUpdateWindow with UI and functionality

### DIFF
--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForUpdateWindow.xaml
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForUpdateWindow.xaml
@@ -1,0 +1,72 @@
+﻿<Window x:Class="EduFlow.Desktop.Windows.GroupForWindows.GroupForUpdateWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:EduFlow.Desktop.Windows.GroupForWindows"
+        mc:Ignorable="d"
+        Title="GroupForUpdateWindow"
+        Height="300"
+        Width="400"
+        WindowStyle="None"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="50"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0">
+            <TextBlock Text="Guruh yaratish"
+                       FontSize="20"
+                       FontFamily="Jetbrains Mono"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center"
+                       Margin="10 0 0 0"/>
+
+            <RadioButton x:Name="closeBtn"
+                         Style="{DynamicResource StateButton}"
+                         Tag="close"
+                         HorizontalAlignment="Right"
+                         Click="closeBtn_Click"/>
+        </Grid>
+
+        <StackPanel Grid.Row="1"
+                    Margin="10 0"
+                    VerticalAlignment="Center">
+            <TextBlock Text="Nomi"
+                       FontSize="13"
+                       FontFamily="Jetbrains Mono"
+                       FontWeight="Medium"
+                       Foreground="Gray"
+                       Margin="10 0"/>
+
+            <TextBox x:Name="nameTxt"
+                     Style="{DynamicResource CustomTextBoxStyle}"
+                     FontWeight="SemiBold"/>
+
+            <ComboBox x:Name="courseComboBox"
+                      Style="{DynamicResource CustomComboBoxStyle}"
+                      FontWeight="SemiBold"
+                      FontSize="18"
+                      Margin="0 10"
+                      FontFamily="Jetbrains Mono"
+                      VerticalContentAlignment="Center">
+                <ComboBoxItem Content="Kurs tanlang" IsSelected="True" IsEnabled="False"/>
+            </ComboBox>
+
+            <ComboBox x:Name="teacherComboBox"
+                      Style="{DynamicResource CustomComboBoxStyle}"
+                      FontWeight="SemiBold"
+                      FontSize="18"
+                      Margin="0 10"
+                      FontFamily="Jetbrains Mono"
+                      VerticalContentAlignment="Center">
+                <ComboBoxItem Content="O'qituvchi tanlang" IsSelected="True" IsEnabled="False"/>
+            </ComboBox>
+
+            <Button x:Name="saveBtn"
+                    Style="{DynamicResource saveButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForUpdateWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForUpdateWindow.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows;
+
+namespace EduFlow.Desktop.Windows.GroupForWindows;
+
+/// <summary>
+/// Interaction logic for GroupForUpdateWindow.xaml
+/// </summary>
+public partial class GroupForUpdateWindow : Window
+{
+    public GroupForUpdateWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void closeBtn_Click(object sender, RoutedEventArgs e)
+        => this.Close();
+}


### PR DESCRIPTION
This commit introduces a new WPF window named `GroupForUpdateWindow`. The XAML file defines the layout and UI elements, including a title, a close button, text blocks, text boxes, and combo boxes for selecting a course and a teacher. The window is styled with specific resources and is set to open in the center of the screen. The code-behind file contains the logic for the window, including a constructor that initializes the components and an event handler for the close button that closes the window when clicked.