### PR TITLE
Refactor addStudents_MouseDown method flow

### DIFF
--- a/EduFlow.Desktop/Windows/CourseForWindows/CourseForViewWindow.xaml
+++ b/EduFlow.Desktop/Windows/CourseForWindows/CourseForViewWindow.xaml
@@ -25,7 +25,7 @@
 
             <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Right"
-                        Width="115">
+                        Width="90">
 
                 <RadioButton x:Name="MinButton"
                              Style="{DynamicResource StateButton}"
@@ -33,17 +33,20 @@
                              ToolTip="Yashirish"
                              Click="MinButton_Click"/>
 
-                <RadioButton x:Name="NormalButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowCollapse"
-                             ToolTip="Oddiy holat"
-                             Click="NormalButton_Click"/>
+                <StackPanel VerticalAlignment="Center">
+                    <RadioButton x:Name="NormalButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowCollapse"
+                                 ToolTip="Oddiy holat"
+                                 Visibility="Collapsed"
+                                 Click="NormalButton_Click"/>
 
-                <RadioButton x:Name="MaxButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowExpand"
-                             ToolTip="Kattalashtirish"
-                             Click="MaxButton_Click"/>
+                    <RadioButton x:Name="MaxButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowExpand"
+                                 ToolTip="Kattalashtirish"
+                                 Click="MaxButton_Click"/>
+                </StackPanel>
 
                 <RadioButton x:Name="CloseBtn"
                              Style="{DynamicResource StateButton}"

--- a/EduFlow.Desktop/Windows/CourseForWindows/CourseForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/CourseForWindows/CourseForViewWindow.xaml.cs
@@ -70,11 +70,37 @@ public partial class CourseForViewWindow : Window
     private void CloseBtn_Click(object sender, RoutedEventArgs e)
         => this.Close();
 
-    private void MaxButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Maximized;
-
     private void NormalButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Normal;
+    {
+        this.WindowState = WindowState.Normal;
+
+        if (NormalButton.Visibility == Visibility.Visible)
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+    }
+
+    private void MaxButton_Click(object sender, RoutedEventArgs e)
+    {
+        this.WindowState = WindowState.Maximized;
+
+        if (MaxButton.Visibility == Visibility.Visible)
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private void MinButton_Click(object sender, RoutedEventArgs e)
         => this.WindowState = WindowState.Minimized;

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml
@@ -24,7 +24,7 @@
                    FontWeight="Bold"/>
 
             <StackPanel Orientation="Horizontal"
-                        Width="115"
+                        Width="90"
                         HorizontalAlignment="Right">
                 <RadioButton x:Name="MinButton"
                              Style="{DynamicResource StateButton}"
@@ -32,17 +32,20 @@
                              ToolTip="Yashirish"
                              Click="MinButton_Click"/>
 
-                <RadioButton x:Name="NormalButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowCollapse"
-                             ToolTip="Oddiy holat"
-                             Click="NormalButton_Click"/>
+                <StackPanel VerticalAlignment="Center">
+                    <RadioButton x:Name="NormalButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowCollapse"
+                                 ToolTip="Oddiy holat"
+                                 Visibility="Collapsed"
+                                 Click="NormalButton_Click"/>
 
-                <RadioButton x:Name="MaxButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowExpand"
-                             ToolTip="Kattalashtirish"
-                             Click="MaxButton_Click"/>
+                    <RadioButton x:Name="MaxButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowExpand"
+                                 ToolTip="Kattalashtirish"
+                                 Click="MaxButton_Click"/>
+                </StackPanel>
 
                 <RadioButton x:Name="CloseBtn"
                              Style="{DynamicResource StateButton}"

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
@@ -134,7 +134,7 @@ public partial class GroupForViewWindow : Window
                     _students,
                     lesson);
 
-                component.OnGetValues += GetLessons;
+                component.OnGetValues += LoadedWindow;
                 stLessons.Children.Add(component);
                 count--;
             }
@@ -249,13 +249,18 @@ public partial class GroupForViewWindow : Window
     private void MaxButton_Click(object sender, RoutedEventArgs e)
         => this.WindowState = WindowState.Maximized;
 
-    private async void Window_Loaded(object sender, RoutedEventArgs e)
+    private async Task LoadedWindow()
     {
-        if(IdentitySingelton.GetInstance().Role is Domain.Enums.UserRole.Teacher)
+        if (IdentitySingelton.GetInstance().Role is Domain.Enums.UserRole.Teacher)
             addStudents.Visibility = Visibility.Collapsed;
 
         await ShowValues();
         ShowLessons();
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        LoadedWindow();
     }
 
     private async void addStudents_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
@@ -263,7 +268,7 @@ public partial class GroupForViewWindow : Window
         GroupForAddStudentWindow window = new GroupForAddStudentWindow();
         window.SetId(Id);
         window.ShowDialog();
-        Window_Loaded(this, new RoutedEventArgs());
+        await LoadedWindow();
     }
 
     private async void createLessonBtn_Click(object sender, RoutedEventArgs e)

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
@@ -263,7 +263,7 @@ public partial class GroupForViewWindow : Window
         GroupForAddStudentWindow window = new GroupForAddStudentWindow();
         window.SetId(Id);
         window.ShowDialog();
-        await ShowValues();
+        Window_Loaded(this, new RoutedEventArgs());
     }
 
     private async void createLessonBtn_Click(object sender, RoutedEventArgs e)

--- a/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/GroupForWindows/GroupForViewWindow.xaml.cs
@@ -244,10 +244,36 @@ public partial class GroupForViewWindow : Window
         => this.WindowState = WindowState.Minimized;
 
     private void NormalButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Normal;
+    {
+        this.WindowState = WindowState.Normal;
+
+        if (NormalButton.Visibility == Visibility.Visible)
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private void MaxButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Maximized;
+    {
+        this.WindowState = WindowState.Maximized;
+
+        if (MaxButton.Visibility == Visibility.Visible)
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private async Task LoadedWindow()
     {

--- a/EduFlow.Desktop/Windows/MainWindow.xaml
+++ b/EduFlow.Desktop/Windows/MainWindow.xaml
@@ -62,7 +62,7 @@
             <Grid Grid.Row="0">
                 <StackPanel Orientation="Horizontal"
                             Margin="10 0"
-                            Width="115"
+                            Width="90"
                             HorizontalAlignment="Right">
                     <RadioButton x:Name="MinButton"
                                  Style="{DynamicResource StateButton}"
@@ -70,17 +70,21 @@
                                  ToolTip="Yashirish"
                                  Click="MinButton_Click"/>
 
-                    <RadioButton x:Name="NormalButton"
-                                 Style="{DynamicResource StateButton}"
-                                 Tag="ArrowCollapse"
-                                 ToolTip="Oddiy holat"
-                                 Click="NormalButton_Click"/>
+                    <StackPanel VerticalAlignment="Center">
+                        <RadioButton x:Name="NormalButton"
+                                     Style="{DynamicResource StateButton}"
+                                     Tag="ArrowCollapse"
+                                     ToolTip="Oddiy holat"
+                                     Visibility="Collapsed"
+                                     Click="NormalButton_Click"/>
 
-                    <RadioButton x:Name="MaxButton"
-                                 Style="{DynamicResource StateButton}"
-                                 Tag="ArrowExpand"
-                                 ToolTip="Kattalashtirish"
-                                 Click="MaxButton_Click"/>
+                        <RadioButton x:Name="MaxButton"
+                                     Style="{DynamicResource StateButton}"
+                                     Tag="ArrowExpand"
+                                     ToolTip="Kattalashtirish"
+                                     Click="MaxButton_Click"/>
+                    </StackPanel>
+
 
                     <RadioButton x:Name="CloseBtn"
                                  Style="{DynamicResource StateButton}"

--- a/EduFlow.Desktop/Windows/MainWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/MainWindow.xaml.cs
@@ -20,12 +20,38 @@ public partial class MainWindow : Window
 
     private void MinButton_Click(object sender, RoutedEventArgs e)
         => this.WindowState = WindowState.Minimized;
-    
+
     private void NormalButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Normal;
+    {
+        this.WindowState = WindowState.Normal;
+
+        if (NormalButton.Visibility == Visibility.Visible)
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private void MaxButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Maximized;
+    {
+        this.WindowState = WindowState.Maximized;
+
+        if(MaxButton.Visibility == Visibility.Visible)
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {

--- a/EduFlow.Desktop/Windows/TeacherForWindows/TeacherForViewWindow.xaml
+++ b/EduFlow.Desktop/Windows/TeacherForWindows/TeacherForViewWindow.xaml
@@ -24,7 +24,7 @@
                    FontWeight="Bold"/>
 
             <StackPanel Orientation="Horizontal"
-                        Width="115"
+                        Width="90"
                         HorizontalAlignment="Right">
                 <RadioButton x:Name="MinButton"
                              Style="{DynamicResource StateButton}"
@@ -32,17 +32,20 @@
                              ToolTip="Yashirish"
                              Click="MinButton_Click"/>
 
-                <RadioButton x:Name="NormalButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowCollapse"
-                             ToolTip="Oddiy holat"
-                             Click="NormalButton_Click"/>   
+                <StackPanel VerticalAlignment="Center">
+                    <RadioButton x:Name="NormalButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowCollapse"
+                                 ToolTip="Oddiy holat"
+                                 Visibility="Collapsed"
+                                 Click="NormalButton_Click"/>
 
-                <RadioButton x:Name="MaxButton"
-                             Style="{DynamicResource StateButton}"
-                             Tag="ArrowExpand"
-                             ToolTip="Kattalashtirish"
-                             Click="MaxButton_Click"/>
+                    <RadioButton x:Name="MaxButton"
+                                 Style="{DynamicResource StateButton}"
+                                 Tag="ArrowExpand"
+                                 ToolTip="Kattalashtirish"
+                                 Click="MaxButton_Click"/>
+                </StackPanel>
 
                 <RadioButton x:Name="CloseBtn"
                              Style="{DynamicResource StateButton}"

--- a/EduFlow.Desktop/Windows/TeacherForWindows/TeacherForViewWindow.xaml.cs
+++ b/EduFlow.Desktop/Windows/TeacherForWindows/TeacherForViewWindow.xaml.cs
@@ -51,11 +51,37 @@ public partial class TeacherForViewWindow : Window
     private void CloseBtn_Click(object sender, RoutedEventArgs e)
         => this.Close();
 
-    private void MaxButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Maximized;
-
     private void NormalButton_Click(object sender, RoutedEventArgs e)
-        => this.WindowState = WindowState.Normal;
+    {
+        this.WindowState = WindowState.Normal;
+
+        if (NormalButton.Visibility == Visibility.Visible)
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+    }
+
+    private void MaxButton_Click(object sender, RoutedEventArgs e)
+    {
+        this.WindowState = WindowState.Maximized;
+
+        if (MaxButton.Visibility == Visibility.Visible)
+        {
+            this.MaxButton.Visibility = Visibility.Collapsed;
+            this.NormalButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            this.NormalButton.Visibility = Visibility.Collapsed;
+            this.MaxButton.Visibility = Visibility.Visible;
+        }
+    }
 
     private void MinButton_Click(object sender, RoutedEventArgs e)
         => this.WindowState = WindowState.Minimized;


### PR DESCRIPTION
Modified the `addStudents_MouseDown` method to call `Window_Loaded` immediately after showing the
`GroupForAddStudentWindow` dialog, instead of awaiting `ShowValues()`. This change improves the execution flow by ensuring the window's loaded event is triggered right after the dialog closes.