### PR TITLE
Add row definitions to MainWindow.xaml Grid

### DIFF
--- a/EduFlow.Cashier.Desktop/Windows/MainWindow.xaml
+++ b/EduFlow.Cashier.Desktop/Windows/MainWindow.xaml
@@ -13,6 +13,7 @@
         WindowStartupLocation="CenterScreen"
         Loaded="Window_Loaded">
     <Grid>
+        
         <Grid.RowDefinitions>
             <RowDefinition Height="30"/>
             <RowDefinition Height="50"/>


### PR DESCRIPTION
This update introduces a Grid.RowDefinitions section to the Grid element in MainWindow.xaml. It defines three rows with specific heights: 30, 50, and a flexible height for the third row, enhancing the layout structure.