### PR TITLE
Change BASE_URL to static readonly field

### DIFF
--- a/EduFlow.Desktop.Integrated/Api/Auth/AuthApi.cs
+++ b/EduFlow.Desktop.Integrated/Api/Auth/AuthApi.cs
@@ -4,7 +4,7 @@ namespace EduFlow.Desktop.Integrated.Api.Auth;
 
 public static class AuthApi
 {
-    public static string BASE_URL => ConfigurationManager.GetValue("ApiConfig:BaseUrl");
-    //public static readonly string BASE_URL = "http://185.191.141.237";
+    //public static string BASE_URL => ConfigurationManager.GetValue("ApiConfig:BaseUrl");
+    public static readonly string BASE_URL = "http://185.191.141.237";
     public static readonly string LOGIN_URL = BASE_URL + "/api/auth/login";
 }


### PR DESCRIPTION
Updated the `BASE_URL` from a configuration-based property to a hardcoded static readonly field. Adjusted the commented-out line to reflect this change.